### PR TITLE
Issue#91 - Make 'prefer external objects' is more apparent as a test …

### DIFF
--- a/classes/form/settings_form.php
+++ b/classes/form/settings_form.php
@@ -50,6 +50,7 @@ class settings_form extends \moodleform {
         $mform = $this->define_file_transfer_section($mform, $config);
         $mform = $this->define_client_selection($mform, $config);
         $mform = $this->define_client_section($mform, $config);
+        $mform = $this->define_testing_section($mform, $config);
 
         foreach ($config as $key => $value) {
             $mform->setDefault($key, $value);
@@ -66,6 +67,21 @@ class settings_form extends \moodleform {
         return $mform;
     }
 
+    public function define_testing_section($mform, $config) {
+        global $OUTPUT;
+        $mform->addElement('header', 'testingheader', get_string('settings:testingheader', 'tool_objectfs'));
+        $mform->setExpanded('testingheader');
+
+        $alert = get_string('settings:testingdescr', 'tool_objectfs');
+        $mform->addElement('html', $OUTPUT->notification($alert, 'warning'));
+
+        $mform->addElement('advcheckbox', 'preferexternal', get_string('settings:preferexternal', 'tool_objectfs'));
+        $mform->addHelpButton('preferexternal', 'settings:preferexternal', 'tool_objectfs');
+        $mform->setType("preferexternal", PARAM_INT);
+
+        return $mform;
+    }
+
     public function define_general_section($mform, $config) {
         $mform->addElement('header', 'generalheader', get_string('settings:generalheader', 'tool_objectfs'));
         $mform->setExpanded('generalheader');
@@ -77,10 +93,6 @@ class settings_form extends \moodleform {
         $mform->addHelpButton('maxtaskruntime', 'settings:maxtaskruntime', 'tool_objectfs');
         $mform->disabledIf('maxtaskruntime', 'enabletasks');
         $mform->setType("maxtaskruntime", PARAM_INT);
-
-        $mform->addElement('advcheckbox', 'preferexternal', get_string('settings:preferexternal', 'tool_objectfs'));
-        $mform->addHelpButton('preferexternal', 'settings:preferexternal', 'tool_objectfs');
-        $mform->setType("preferexternal", PARAM_INT);
 
         $mform->addElement('advcheckbox', 'enablelogging', get_string('settings:enablelogging', 'tool_objectfs'));
         $mform->addHelpButton('enablelogging', 'settings:enablelogging', 'tool_objectfs');

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -110,3 +110,6 @@ $string['settings:deletesuccess'] = 'Could delete object from the external objec
 $string['settings:deleteerror'] = 'Could not delete object from the external object storage. ';
 $string['settings:permissioncheckpassed'] = 'Permissions check passed.';
 $string['settings:handlernotset'] = '$CFG->alternative_file_system_class is not set, the file system will not be able to read from the external object storage. Background tasks can still function.';
+
+$string['settings:testingheader'] = 'Test Settings';
+$string['settings:testingdescr'] = 'This setting is mainly for testing purposes and introduces overhead to check the location.';


### PR DESCRIPTION
I have moved "prefer external object" to a separate section called 'Test Settings'