### PR TITLE
Issue #108 - remove redundant Max() in 'get candidate object' query

### DIFF
--- a/classes/object_manipulator/deleter.php
+++ b/classes/object_manipulator/deleter.php
@@ -87,15 +87,15 @@ class deleter extends manipulator {
         }
 
         $sql = 'SELECT f.contenthash,
-                       MAX(f.filesize) AS filesize
+                       f.filesize
                   FROM {files} f
              LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
                  WHERE o.timeduplicated <= ?
                        AND o.location = ?
+                       AND f.filesize > ?
               GROUP BY f.contenthash,
                        f.filesize,
-                       o.location
-                HAVING MAX(f.filesize) > ?';
+                       o.location';
 
         $consistancythrehold = time() - $this->consistencydelay;
         $params = array($consistancythrehold, OBJECT_LOCATION_DUPLICATED, $this->sizethreshold);

--- a/classes/object_manipulator/puller.php
+++ b/classes/object_manipulator/puller.php
@@ -64,13 +64,13 @@ class puller extends manipulator {
     public function get_candidate_objects() {
         global $DB;
         $sql = 'SELECT f.contenthash,
-                       MAX(f.filesize) AS filesize
+                       f.filesize
                   FROM {files} f
              LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
               GROUP BY f.contenthash,
                        f.filesize,
                        o.location
-                HAVING MAX(f.filesize) <= ?
+                HAVING (f.filesize <= ?)
                        AND (o.location = ?)';
 
         $params = array($this->sizethreshold, OBJECT_LOCATION_EXTERNAL);

--- a/classes/object_manipulator/pusher.php
+++ b/classes/object_manipulator/pusher.php
@@ -89,7 +89,7 @@ class pusher extends manipulator {
                        AND f.filesize > :threshold
                        AND f.filesize < :maximum_file_size
                        AND (o.location IS NULL OR o.location = :object_location)
-              GROUP BY f.contenthash,
+              GROUP BY f.contenthash, f.filesize
                        o.location';
 
         $maxcreatedtimestamp = time() - $this->minimumage;

--- a/classes/object_manipulator/pusher.php
+++ b/classes/object_manipulator/pusher.php
@@ -85,12 +85,12 @@ class pusher extends manipulator {
                        f.filesize AS filesize
                   FROM {files} f
              LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
-              GROUP BY f.contenthash,
-                       o.location
-                HAVING MIN(f.timecreated) <= :maxcreatedtimstamp
+                WHERE (f.timecreated) <= :maxcreatedtimstamp
                        AND f.filesize > :threshold
                        AND f.filesize < :maximum_file_size
-                       AND (o.location IS NULL OR o.location = :object_location)';
+                       AND (o.location IS NULL OR o.location = :object_location)
+              GROUP BY f.contenthash,
+                       o.location';
 
         $maxcreatedtimestamp = time() - $this->minimumage;
 

--- a/classes/object_manipulator/pusher.php
+++ b/classes/object_manipulator/pusher.php
@@ -82,14 +82,14 @@ class pusher extends manipulator {
     public function get_candidate_objects() {
         global $DB;
         $sql = 'SELECT f.contenthash,
-                       MAX(f.filesize) AS filesize
+                       f.filesize AS filesize
                   FROM {files} f
              LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
               GROUP BY f.contenthash,
                        o.location
                 HAVING MIN(f.timecreated) <= :maxcreatedtimstamp
-                       AND MAX(f.filesize) > :threshold
-                       AND MAX(f.filesize) < :maximum_file_size
+                       AND f.filesize > :threshold
+                       AND f.filesize < :maximum_file_size
                        AND (o.location IS NULL OR o.location = :object_location)';
 
         $maxcreatedtimestamp = time() - $this->minimumage;

--- a/classes/object_manipulator/recoverer.php
+++ b/classes/object_manipulator/recoverer.php
@@ -57,7 +57,7 @@ class recoverer extends manipulator {
         global $DB;
 
         $sql = 'SELECT f.contenthash,
-                       MAX(f.filesize) AS filesize
+                       f.filesize
                   FROM {files} f
              LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
                  WHERE o.location = ?


### PR DESCRIPTION
As suggested by Evan https://github.com/catalyst/moodle-tool_objectfs/issues/108.
