### PR TITLE
unit test, fix leading 0 in file permission

### DIFF
--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -82,8 +82,8 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $reflection->setAccessible(true);
         $localpath = $reflection->invokeArgs($this->filesystem, [$filehash, true]);
 
-        $fileperms = substr(sprintf('%o', fileperms($localpath)), -4);
-        $cfgperms = substr(sprintf('%o', $CFG->filepermissions), -4);
+        $fileperms = substr(sprintf('%04o', fileperms($localpath)), -4);
+        $cfgperms = substr(sprintf('%04o', $CFG->filepermissions), -4);
         $this->assertEquals($cfgperms, $fileperms);
     }
 


### PR DESCRIPTION
issue#134

Fix unit test failure:


    tool_objectfs\tests\object_file_system_testcase::test_get_local_path_from_hash_fetch_remote_will_restore_file_permissions
    Failed asserting that two strings are equal.
    --- Expected
    +++ Actual
    @@ @@
    -'666'
    +'0666'

/var/www/site/admin/tool/objectfs/tests/object_file_system_test.php:87
/var/www/site/lib/phpunit/classes/base_testcase.php:600
/var/www/site/lib/phpunit/classes/advanced_testcase.php:68

To re-run:
vendor/bin/phpunit tool_objectfs\tests\object_file_system_testcase admin/tool/objectfs/tests/object_file_system_test.php

Environment:
PHP: 7.2.17.0.0.18.04.1, pgsql: 9.6.13, OS: Linux 4.4.0-148-generic x86_64
PHPUnit 7.5.11 by Sebastian Bergmann and contributors.



