### PR TITLE
Appending the unit test instance to the dataroot for Totara

### DIFF
--- a/tests/classes/test_client.php
+++ b/tests/classes/test_client.php
@@ -27,7 +27,11 @@ class test_client implements object_client {
 
     public function __construct($config) {
         global $CFG;
-        $this->bucketpath = $CFG->phpunit_dataroot . '/mockbucket';
+        $dataroot = $CFG->phpunit_dataroot;
+        if (defined('PHPUNIT_INSTANCE') && PHPUNIT_INSTANCE !== null) {
+            $dataroot .= '/' . PHPUNIT_INSTANCE;
+        }
+        $this->bucketpath = $dataroot . '/mockbucket';
         if (!is_dir($this->bucketpath)) {
             mkdir($this->bucketpath);
         }


### PR DESCRIPTION
Totara unit tests now use an instance number for parallel unit tests which is appended to the dataroot for the test.
If the mockbucket is not in the correct directory it is not cleared out after each test leading to failed tests.