### PR TITLE
File deletion/trashdir enhancement

### DIFF
--- a/classes/client/object_client.php
+++ b/classes/client/object_client.php
@@ -31,6 +31,9 @@ interface object_client {
     public function __construct($config);
     public function register_stream_wrapper();
     public function get_fullpath_from_hash($contenthash);
+    public function get_trash_fullpath_from_hash($contenthash);
+    public function delete_file($fullpath);
+    public function rename_file($currentpath, $destinationpath);
     public function get_seekable_stream_context();
     public function get_availability();
     public function get_maximum_upload_size();

--- a/classes/client/swift_client.php
+++ b/classes/client/swift_client.php
@@ -178,12 +178,13 @@ class swift_client implements object_client {
     }
 
     public function verify_object($contenthash, $localpath) {
-        $localmd5 = md5_file($localpath);
-        $externalmd5 = $this->get_md5_from_hash($contenthash);
-        if ($localmd5 === $externalmd5) {
+        // For objects uploaded to S3 storage using the multipart upload, the etag will not be the objects MD5.
+        // So we can't compare here to verify the object.
+        // For now we just check that we can retrieve any Etag to verify the object for all supported storages.
+        $retrievemd5 = $this->get_md5_from_hash($contenthash);
+        if ($retrievemd5) {
             return true;
         }
-
         return false;
     }
 

--- a/tests/tool_objectfs_testcase.php
+++ b/tests/tool_objectfs_testcase.php
@@ -121,6 +121,12 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
         return $reflection->invokeArgs($this->filesystem, [$contenthash]);
     }
 
+    protected function get_external_trash_path_from_hash($contenthash) {
+        $reflection = new \ReflectionMethod(object_file_system::class, 'get_external_trash_path_from_hash');
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($this->filesystem, [$contenthash]);
+    }
+
     protected function get_external_path_from_storedfile($file) {
         $contenthash = $file->get_contenthash();
         return $this->get_external_path_from_hash($contenthash);
@@ -133,9 +139,33 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
         return $reflection->invokeArgs($this->filesystem, [$contenthash]);
     }
 
+    protected function get_trash_fullpath_from_hash($contenthash) {
+        $reflection = new \ReflectionMethod(object_file_system::class, 'get_trash_fullpath_from_hash');
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($this->filesystem, [$contenthash]);
+    }
+
+    protected function delete_file($contenthash) {
+        $reflection = new \ReflectionMethod(object_file_system::class, 'delete_file');
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($this->filesystem, [$contenthash]);
+    }
+
+    protected function rename_file($currentpath, $destinationpath) {
+        $reflection = new \ReflectionMethod(object_file_system::class, 'delete_file');
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($this->filesystem, [$currentpath, $destinationpath]);
+    }
+
     protected function get_local_path_from_storedfile($file) {
         $contenthash = $file->get_contenthash();
         return $this->get_local_path_from_hash($contenthash);
+    }
+
+    protected function recover_file($file) {
+        $reflection = new \ReflectionMethod(object_file_system::class, 'recover_file');
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($this->filesystem, [$file]);
     }
 
     protected function create_local_object($content = 'local object content') {
@@ -188,6 +218,21 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
         $reflection = new \ReflectionMethod(object_file_system::class, 'acquire_object_lock');
         $reflection->setAccessible(true);
         return $reflection->invokeArgs($this->filesystem, [$filehash, $timeout]);
+    }
+
+    protected function is_locally_readable_by_hash_in_trashdir($contenthash) {
+        $externalpath = $this->get_trash_fullpath_from_hash($contenthash);
+        return is_readable($externalpath);
+    }
+
+    protected function is_externally_readable_by_hash_in_trashdir($contenthash) {
+        $externalpath = $this->get_external_trash_path_from_hash($contenthash);
+        return is_readable($externalpath);
+    }
+
+    protected function delete_draft_files($contenthash) {
+        global $DB;
+        $DB->delete_records('files', array('contenthash' => $contenthash));
     }
 }
 


### PR DESCRIPTION
File deletion (moving to trashdir) and recovery includes:
- When local file is deleted it goes to local trash dir.
- When external file is deleted it doesn't pull back locally anymore. If `$CFG->tool_objectfs_delete_externally = true` then external file moves to external trash dir. if not - remains in its previous path.
- When duplicated file is deleted it removes locally. If `$CFG->tool_objectfs_delete_externally = true` then external file moves to external trash dir. If not - remains in its previous path.
- Core `recover_file` method was extended to recover external file from external trash dir. 
- PHP function `unlink()` was replaced by method and extended in client class: `unlink()` for S3 storage and `BlobRestProxy->deleteBlob` for Azure storage.
- Tests added to cover new functionality.