### PR TITLE
Remove lock waiting when run cron task

### DIFF
--- a/classes/log/aggregate_logger.php
+++ b/classes/log/aggregate_logger.php
@@ -121,14 +121,4 @@ class aggregate_logger extends objectfs_logger {
         $querystat->add_object_data($objectcount, $objectsum);
         $this->querystatistics[$queryname] = $querystat;
     }
-
-    public function log_lock_timing($lock) {
-        $locktime = $this->get_timing();
-        if ($lock) {
-            $this->error_log('Lock acquired in '.$locktime.' seconds.');
-        } else {
-            $this->error_log('Can\'t acquire lock. Time waited '.$locktime.' seconds.');
-        }
-    }
-
 }

--- a/classes/log/aggregate_logger.php
+++ b/classes/log/aggregate_logger.php
@@ -122,4 +122,13 @@ class aggregate_logger extends objectfs_logger {
         $this->querystatistics[$queryname] = $querystat;
     }
 
+    public function log_lock_timing($lock) {
+        $locktime = $this->get_timing();
+        if ($lock) {
+            $this->error_log('Lock acquired in '.$locktime.' seconds.');
+        } else {
+            $this->error_log('Can\'t acquire lock. Time waited '.$locktime.' seconds.');
+        }
+    }
+
 }

--- a/classes/log/null_logger.php
+++ b/classes/log/null_logger.php
@@ -43,4 +43,8 @@ class null_logger extends objectfs_logger {
         return;
     }
 
+    public function log_lock_timing($lock) {
+        return;
+    }
+
 }

--- a/classes/log/objectfs_logger.php
+++ b/classes/log/objectfs_logger.php
@@ -61,4 +61,5 @@ abstract class objectfs_logger {
     public abstract function log_object_read($readname, $objectpath, $objectsize = 0);
     public abstract function log_object_move($movename, $initallocation, $finallocation, $objecthash, $objectsize = 0);
     public abstract function log_object_query($queryname, $objectcount, $objectsum = 0);
+    public abstract function log_lock_timing($lock);
 }

--- a/classes/log/objectfs_logger.php
+++ b/classes/log/objectfs_logger.php
@@ -58,8 +58,16 @@ abstract class objectfs_logger {
         // @codingStandardsIgnoreEnd
     }
 
+    public function log_lock_timing($lock) {
+        $locktime = $this->get_timing();
+        if ($lock) {
+            $this->error_log('Lock acquired in '.$locktime.' seconds.');
+        } else {
+            $this->error_log('Can\'t acquire lock. Time waited '.$locktime.' seconds.');
+        }
+    }
+
     public abstract function log_object_read($readname, $objectpath, $objectsize = 0);
     public abstract function log_object_move($movename, $initallocation, $finallocation, $objecthash, $objectsize = 0);
     public abstract function log_object_query($queryname, $objectcount, $objectsum = 0);
-    public abstract function log_lock_timing($lock);
 }

--- a/classes/log/real_time_logger.php
+++ b/classes/log/real_time_logger.php
@@ -90,4 +90,13 @@ class real_time_logger extends objectfs_logger {
         error_log($logstring);
         // @codingStandardsIgnoreEnd
     }
+
+    public function log_lock_timing($lock) {
+        $locktime = $this->get_timing();
+        if ($lock) {
+            $this->error_log('Lock acquired in '.$locktime.' seconds.');
+        } else {
+            $this->error_log('Can\'t acquire lock. Time waited '.$locktime.' seconds.');
+        }
+    }
 }

--- a/classes/log/real_time_logger.php
+++ b/classes/log/real_time_logger.php
@@ -90,13 +90,4 @@ class real_time_logger extends objectfs_logger {
         error_log($logstring);
         // @codingStandardsIgnoreEnd
     }
-
-    public function log_lock_timing($lock) {
-        $locktime = $this->get_timing();
-        if ($lock) {
-            $this->error_log('Lock acquired in '.$locktime.' seconds.');
-        } else {
-            $this->error_log('Can\'t acquire lock. Time waited '.$locktime.' seconds.');
-        }
-    }
 }

--- a/classes/object_file_system.php
+++ b/classes/object_file_system.php
@@ -107,7 +107,7 @@ abstract class object_file_system extends \file_system_filedir {
         if ($fetchifnotfound && !is_readable($path)) {
 
             // Try and pull from remote.
-            $objectlock = $this->acquire_object_lock($contenthash);
+            $objectlock = $this->acquire_object_lock($contenthash, 600);
 
             // While gaining lock object might have been moved locally so we recheck.
             if ($objectlock && !is_readable($path)) {
@@ -200,11 +200,14 @@ abstract class object_file_system extends \file_system_filedir {
     }
 
     // Acquire the object lock any time you are moving an object between locations.
-    public function acquire_object_lock($contenthash) {
-        $timeout = 600; // 10 minutes before giving up.
+    public function acquire_object_lock($contenthash, $timeout = 0) {
         $resource = "tool_objectfs: $contenthash";
         $lockfactory = \core\lock\lock_config::get_lock_factory('tool_objectfs_object');
+        $this->logger->start_timing();
         $lock = $lockfactory->get_lock($resource, $timeout);
+        $this->logger->end_timing();
+        $this->logger->log_lock_timing($lock);
+
         return $lock;
     }
 

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -449,5 +449,15 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $this->assertTrue($this->is_externally_readable_by_hash($filehash));
     }
 
+    public function test_object_storage_locker_can_acquire_lock_if_object_is_not_locked() {
+        $this->filesystem = new test_file_system();
+        $file = $this->create_local_file();
+        $filehash = $file->get_contenthash();
+        $lock = $this->acquire_object_lock($filehash);
+        $this->assertEquals(gettype($lock), 'object');
+        $this->assertEquals(get_class($lock), 'core\lock\lock');
+        $lock->release();
+    }
+
 }
 

--- a/tests/tool_objectfs_testcase.php
+++ b/tests/tool_objectfs_testcase.php
@@ -183,5 +183,11 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
         $externalpath = $this->get_external_path_from_hash($contenthash);
         return is_readable($externalpath);
     }
+
+    protected function acquire_object_lock($filehash, $timeout = 0) {
+        $reflection = new \ReflectionMethod(object_file_system::class, 'acquire_object_lock');
+        $reflection->setAccessible(true);
+        return $reflection->invokeArgs($this->filesystem, [$filehash, $timeout]);
+    }
 }
 


### PR DESCRIPTION
Issue #140:
- Remove lock waiting when run cron task.
- Add lock timing and status logging if the plugin has logging turned on.
- Add a test to acquire a lock if object is not locked.