### PR TITLE
Fix for issue #144 Duplicate records error when running task/delete_local_objects

### DIFF
--- a/classes/object_manipulator/deleter.php
+++ b/classes/object_manipulator/deleter.php
@@ -77,7 +77,8 @@ class deleter extends manipulator {
 
     protected function get_candidates_sql() {
 
-        $sql = 'SELECT f.contenthash,
+        $sql = 'SELECT MAX(f.id),
+                       f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
              LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash

--- a/classes/object_manipulator/puller.php
+++ b/classes/object_manipulator/puller.php
@@ -59,7 +59,8 @@ class puller extends manipulator {
     }
 
     protected function get_candidates_sql() {
-        $sql = 'SELECT f.contenthash,
+        $sql = 'SELECT MAX(f.id),
+                       f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
              LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash

--- a/classes/object_manipulator/pusher.php
+++ b/classes/object_manipulator/pusher.php
@@ -75,7 +75,8 @@ class pusher extends manipulator {
     }
 
     protected function get_candidates_sql() {
-        $sql = 'SELECT f.contenthash,
+        $sql = 'SELECT MAX(f.id),
+                       f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
              LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash

--- a/classes/object_manipulator/recoverer.php
+++ b/classes/object_manipulator/recoverer.php
@@ -51,7 +51,8 @@ class recoverer extends manipulator {
     }
 
     protected function get_candidates_sql() {
-        $sql = 'SELECT f.contenthash,
+        $sql = 'SELECT MAX(f.id),
+                       f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
              LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash

--- a/tests/deleter_test.php
+++ b/tests/deleter_test.php
@@ -53,7 +53,9 @@ class deleter_testcase extends tool_objectfs_testcase {
 
         $candidateobjects = $this->deleter->get_candidate_objects();
 
-        $this->assertArrayHasKey($duplicatedbject->contenthash, $candidateobjects);
+        foreach ($candidateobjects as $candidate) {
+            $this->assertEquals($duplicatedbject->contenthash, $candidate->contenthash);
+        }
     }
 
     public function test_deleter_get_candidate_objects_will_not_get_local_or_remote_objects() {

--- a/tests/puller_test.php
+++ b/tests/puller_test.php
@@ -51,7 +51,9 @@ class puller_testcase extends tool_objectfs_testcase {
 
         $candidateobjects = $this->puller->get_candidate_objects();
 
-        $this->assertArrayHasKey($remoteobject->contenthash, $candidateobjects);
+        foreach ($candidateobjects as $candidate) {
+            $this->assertEquals($remoteobject->contenthash, $candidate->contenthash);
+        }
     }
 
     public function test_puller_get_candidate_objects_will_not_get_duplicated_or_local_objects() {

--- a/tests/pusher_test.php
+++ b/tests/pusher_test.php
@@ -51,8 +51,13 @@ class pusher_testcase extends tool_objectfs_testcase {
         $object = $this->create_local_object();
 
         $candidateobjects = $this->pusher->get_candidate_objects();
-
-        $this->assertArrayHasKey($object->contenthash, $candidateobjects);
+        $objectfound = false;
+        foreach ($candidateobjects as $candidate) {
+            if ($object->contenthash === $candidate->contenthash) {
+                $objectfound = true;
+            }
+        }
+        $this->assertTrue($objectfound);
     }
 
     public function test_pusher_get_candidate_objects_wont_get_duplicated_or_remote_objects() {

--- a/tests/recoverer_test.php
+++ b/tests/recoverer_test.php
@@ -44,7 +44,9 @@ class recoverer_testcase extends tool_objectfs_testcase {
 
         $candidateobjects = $this->recoverer->get_candidate_objects();
 
-        $this->assertArrayHasKey($recovererobject->contenthash, $candidateobjects);
+        foreach ($candidateobjects as $candidate) {
+            $this->assertEquals($recovererobject->contenthash, $candidate->contenthash);
+        }
     }
 
     public function test_recoverer_will_recover_local_objects() {


### PR DESCRIPTION
Fix for issue #144 Duplicate records error when running task/delete_local_objects:
- Add first unique field `id` to get_candidates_sql methods.
- Adjust tests.