### PR TITLE
Fix issue 161, add a test to cover the case

### DIFF
--- a/classes/object_file_system.php
+++ b/classes/object_file_system.php
@@ -537,8 +537,6 @@ abstract class object_file_system extends \file_system_filedir {
 
         if (file_exists($trashfile)) {
             // A copy of this file is already in the trash.
-            // Remove the old version.
-            $this->delete_object_from_hash($contenthash);
             return;
         }
 
@@ -597,7 +595,7 @@ abstract class object_file_system extends \file_system_filedir {
     /**
      * Deletes file from local filesystem by its hash
      *
-     * @param string $contenthash file to be copied
+     * @param string $contenthash file to be deleted
      */
     public function delete_local_file_from_hash($contenthash) {
         $path = $this->get_local_path_from_hash($contenthash);

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -494,4 +494,19 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $this->recover_file($file);
         $this->assertTrue($this->is_externally_readable_by_hash($filehash));
     }
+
+    public function test_can_delete_local_file_if_exists_in_trashdir() {
+        $this->filesystem = new test_file_system();
+        $file = $this->create_local_file();
+        $filehash = $file->get_contenthash();
+        $this->delete_draft_files($filehash);
+        $this->filesystem->remove_file($filehash);
+        $this->assertFalse($this->is_locally_readable_by_hash($filehash));
+
+        $file = $this->create_local_file();
+        $filehash = $file->get_contenthash();
+        $this->delete_draft_files($filehash);
+        $this->filesystem->remove_file($filehash);
+        $this->assertFalse($this->is_locally_readable_by_hash($filehash));
+    }
 }


### PR DESCRIPTION
Issue #161 
Moving a local file to trashdir has two steps:
- Copying the file from filedir to trashdir.
- Deleting the file from filedir.

When the local file already exists in trashdir there might be two possible ways to follow:
- Overwrite the file in trashdir, or
- Leave the previous version of the file in trashdir and just delete the file from filedir.

In this PR the second way is implemented, as the first one looks a little bit redundant.

A test is added as well to cover the issue.