### PR TITLE
Cron tasks optimization

### DIFF
--- a/classes/local/form/settings_form.php
+++ b/classes/local/form/settings_form.php
@@ -156,7 +156,7 @@ class settings_form extends \moodleform {
 
         if (isset($CFG->alternative_file_system_class)) {
             if ($CFG->alternative_file_system_class != $config->filesystem) {
-                $string = get_string('settings:clientselection:mismatchfilesystem','tool_objectfs');
+                $string = get_string('settings:clientselection:mismatchfilesystem', 'tool_objectfs');
                 $mform->addElement('html', $OUTPUT->notification($string, 'notifyproblem'));
             }
         } else {

--- a/classes/local/form/settings_form.php
+++ b/classes/local/form/settings_form.php
@@ -41,7 +41,8 @@ class settings_form extends \moodleform {
         $mform = $this->_form;
         $config = $this->_customdata['config'];
 
-        $link = \html_writer::link(new \moodle_url('/admin/tool/objectfs/object_status.php'), get_string('object_status:page', 'tool_objectfs'));
+        $link = \html_writer::link(new \moodle_url('/admin/tool/objectfs/object_status.php'),
+            get_string('object_status:page', 'tool_objectfs'));
 
         $mform->addElement('html', $OUTPUT->heading($link, 5));
 
@@ -155,10 +156,12 @@ class settings_form extends \moodleform {
 
         if (isset($CFG->alternative_file_system_class)) {
             if ($CFG->alternative_file_system_class != $config->filesystem) {
-                $mform->addElement('html', $OUTPUT->notification(get_string('settings:clientselection:mismatchfilesystem', 'tool_objectfs'), 'notifyproblem'));
+                $string = get_string('settings:clientselection:mismatchfilesystem','tool_objectfs');
+                $mform->addElement('html', $OUTPUT->notification($string, 'notifyproblem'));
             }
         } else {
-            $mform->addElement('html', $OUTPUT->notification(get_string('settings:clientselection:filesystemnotdefined', 'tool_objectfs'), 'warning'));
+            $string = get_string('settings:clientselection:filesystemnotdefined', 'tool_objectfs');
+            $mform->addElement('html', $OUTPUT->notification($string, 'warning'));
         }
 
         return $mform;
@@ -167,22 +170,28 @@ class settings_form extends \moodleform {
     public function define_presignedurl_section($mform) {
         global $OUTPUT;
 
-        $mform->addElement('header', 'presignedurlheader', get_string('settings:presignedurl:header', 'tool_objectfs'));
+        $mform->addElement('header', 'presignedurlheader',
+            get_string('settings:presignedurl:header', 'tool_objectfs'));
         $mform->setExpanded('presignedurlheader');
 
-        $link = \html_writer::link(new \moodle_url('/admin/tool/objectfs/presignedurl_tests.php'), get_string('presignedurl_testing:page', 'tool_objectfs'));
-        $text = $OUTPUT->heading('Before enabling Pre-Signed URL, please, make sure that all tests are passed successfully: '.$link, 6);
+        $link = \html_writer::link(new \moodle_url('/admin/tool/objectfs/presignedurl_tests.php'),
+            get_string('presignedurl_testing:page', 'tool_objectfs'));
+
+        $text = $OUTPUT->heading(get_string('settings:presignedurl:warning', 'tool_objectfs').$link, 6);
         $mform->addElement('html', $OUTPUT->notification($text, 'warning'));
 
-        $mform->addElement('advcheckbox', 'enablepresignedurls', get_string('settings:presignedurl:enablepresignedurls', 'tool_objectfs'));
+        $mform->addElement('advcheckbox', 'enablepresignedurls',
+            get_string('settings:presignedurl:enablepresignedurls', 'tool_objectfs'));
         $mform->addHelpButton('enablepresignedurls', 'settings:presignedurl:enablepresignedurls', 'tool_objectfs');
         $mform->setType("enablepresignedurls", PARAM_INT);
 
-        $mform->addElement('duration', 'expirationtime', get_string('settings:presignedurl:expirationtime', 'tool_objectfs'));
+        $mform->addElement('duration', 'expirationtime',
+            get_string('settings:presignedurl:expirationtime', 'tool_objectfs'));
         $mform->addHelpButton('expirationtime', 'settings:presignedurl:expirationtime', 'tool_objectfs');
         $mform->setType("expirationtime", PARAM_INT);
 
-        $mform->addElement('text', 'presignedminfilesize', get_string('settings:presignedurl:presignedminfilesize', 'tool_objectfs'));
+        $mform->addElement('text', 'presignedminfilesize',
+            get_string('settings:presignedurl:presignedminfilesize', 'tool_objectfs'));
         $mform->addHelpButton('presignedminfilesize', 'settings:presignedurl:presignedminfilesize', 'tool_objectfs');
         $mform->setType("presignedminfilesize", PARAM_INT);
 

--- a/classes/local/object_manipulator/checker.php
+++ b/classes/local/object_manipulator/checker.php
@@ -51,7 +51,7 @@ class checker extends manipulator {
 
     protected function get_candidates_sql() {
         $sql = 'SELECT f.contenthash
-                  FROM {files} f 
+                  FROM {files} f
              LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
                  WHERE f.filesize > 0
                    AND o.location is NULL

--- a/classes/local/object_manipulator/checker.php
+++ b/classes/local/object_manipulator/checker.php
@@ -27,12 +27,11 @@ namespace tool_objectfs\local\object_manipulator;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
-
 class checker extends manipulator {
 
     /**
-     * Pusher constructor.
+     * Checker constructor.
+     * This manipulator adds location for files that do not have records in {tool_objectfs_objects} table.
      *
      * @param object_client $client remote object client
      * @param object_file_system $filesystem objectfs file system
@@ -52,9 +51,10 @@ class checker extends manipulator {
 
     protected function get_candidates_sql() {
         $sql = 'SELECT f.contenthash
-                  FROM mdl_files f LEFT JOIN mdl_tool_objectfs_objects o ON f.contenthash = o.contenthash
+                  FROM {files} f 
+             LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
                  WHERE f.filesize > 0
-                       AND o.location is NULL
+                   AND o.location is NULL
               GROUP BY f.contenthash';
 
         return $sql;
@@ -62,7 +62,6 @@ class checker extends manipulator {
 
     protected function get_candidates_sql_params() {
         $params = array();
-
         return $params;
     }
 

--- a/classes/local/object_manipulator/checker.php
+++ b/classes/local/object_manipulator/checker.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Checks files to have their location stored in database.
+ *
+ * @package   tool_objectfs
+ * @author    Mikhail Golenkov <mikhailgolenkov@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_objectfs\local\object_manipulator;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
+
+class checker extends manipulator {
+
+    /**
+     * Pusher constructor.
+     *
+     * @param object_client $client remote object client
+     * @param object_file_system $filesystem objectfs file system
+     * @param object $config objectfs config.
+     */
+    public function __construct($filesystem, $config, $logger) {
+        parent::__construct($filesystem, $config);
+
+        $this->logger = $logger;
+        // Inject our logger into the filesystem.
+        $this->filesystem->set_logger($this->logger);
+    }
+
+    protected function get_query_name() {
+        return 'get_check_candidates';
+    }
+
+    protected function get_candidates_sql() {
+        $sql = 'SELECT f.contenthash
+                  FROM mdl_files f LEFT JOIN mdl_tool_objectfs_objects o ON f.contenthash = o.contenthash
+                 WHERE f.filesize > 0
+                       AND o.location is NULL
+              GROUP BY f.contenthash';
+
+        return $sql;
+    }
+
+    protected function get_candidates_sql_params() {
+        $params = array();
+
+        return $params;
+    }
+
+    protected function manipulate_object($objectrecord) {
+        $location = $this->filesystem->get_object_location_from_hash($objectrecord->contenthash);
+        return $location;
+    }
+}

--- a/classes/local/object_manipulator/deleter.php
+++ b/classes/local/object_manipulator/deleter.php
@@ -27,8 +27,6 @@ namespace tool_objectfs\local\object_manipulator;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
-
 class deleter extends manipulator {
 
     /**
@@ -81,10 +79,10 @@ class deleter extends manipulator {
                        f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
-            INNER JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
+                  JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
                  WHERE o.timeduplicated <= ?
-                       AND o.location = ?
-                       AND f.filesize > ?
+                   AND o.location = ?
+                   AND f.filesize > ?
               GROUP BY f.contenthash,
                        f.filesize,
                        o.location';

--- a/classes/local/object_manipulator/deleter.php
+++ b/classes/local/object_manipulator/deleter.php
@@ -81,13 +81,13 @@ class deleter extends manipulator {
                        f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
-             LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
+            INNER JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
                  WHERE o.timeduplicated <= ?
                        AND o.location = ?
+                       AND f.filesize > ?
               GROUP BY f.contenthash,
                        f.filesize,
-                       o.location
-                HAVING MAX(f.filesize) > ?';
+                       o.location';
 
         return $sql;
     }

--- a/classes/local/object_manipulator/logger.php
+++ b/classes/local/object_manipulator/logger.php
@@ -61,14 +61,16 @@ class logger {
     public function log_object_manipulation() {
         $duration = $this->timestart - $this->timeend;
         $totalfilesize = display_size($this->totalfilesize);
-        $logstring = "Objectsfs $this->action manipulator took $duration seconds to $this->action $this->totalfilecount objects. ";
+        $logstring = "Objectsfs $this->action manipulator took $duration seconds ";
+        $logstring .= "to $this->action $this->totalfilecount objects. ";
         $logstring .= "Total size: $totalfilesize Total time: $duration seconds";
         mtrace($logstring);
     }
 
     public function log_object_manipulation_query($totalobjectsfound) {
         $duration = $this->timeend - $this->timestart;
-        $logstring = "Objectsfs $this->action manipulator took $duration seconds to find $totalobjectsfound potential $this->action objects. ";
+        $logstring = "Objectsfs $this->action manipulator took $duration seconds ";
+        $logstring .= "to find $totalobjectsfound potential $this->action objects. ";
         $logstring .= "Total time: $duration seconds";
         mtrace($logstring);
     }

--- a/classes/local/object_manipulator/manipulator.php
+++ b/classes/local/object_manipulator/manipulator.php
@@ -58,7 +58,12 @@ abstract class manipulator {
     public function __construct($filesystem, $config) {
         $this->finishtime = time() + $config->maxtaskruntime;
         $this->filesystem = $filesystem;
-        $this->batchsize = $config->batchsize;
+
+        if (get_class($this) === 'tool_objectfs\\local\\object_manipulator\\checker') {
+            $this->batchsize = $config->batchsize * 10;
+        } else {
+            $this->batchsize = $config->batchsize;
+        }
     }
 
     /**

--- a/classes/local/object_manipulator/manipulator.php
+++ b/classes/local/object_manipulator/manipulator.php
@@ -154,7 +154,8 @@ abstract class manipulator {
         $manipulators = array('deleter',
                               'puller',
                               'pusher',
-                              'recoverer');
+                              'recoverer',
+                              'checker');
 
         foreach ($manipulators as $key => $manipulator) {
             $manipulators[$key] = '\\tool_objectfs\\local\\object_manipulator\\' . $manipulator;

--- a/classes/local/object_manipulator/puller.php
+++ b/classes/local/object_manipulator/puller.php
@@ -27,8 +27,6 @@ namespace tool_objectfs\local\object_manipulator;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
-
 class puller extends manipulator {
 
     /**
@@ -63,9 +61,9 @@ class puller extends manipulator {
                        f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
-            INNER JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
+                  JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
                  WHERE f.filesize <= ?
-                       AND o.location = ?
+                   AND o.location = ?
               GROUP BY f.contenthash,
                        f.filesize,
                        o.location';

--- a/classes/local/object_manipulator/puller.php
+++ b/classes/local/object_manipulator/puller.php
@@ -78,7 +78,9 @@ class puller extends manipulator {
     }
 
     protected function manipulate_object($objectrecord) {
-        $newlocation = $this->filesystem->copy_object_from_external_to_local_by_hash($objectrecord->contenthash, $objectrecord->filesize);
+        $contenthash = $objectrecord->contenthash;
+        $filesize = $objectrecord->filesize;
+        $newlocation = $this->filesystem->copy_object_from_external_to_local_by_hash($contenthash, $filesize);
         return $newlocation;
     }
 }

--- a/classes/local/object_manipulator/puller.php
+++ b/classes/local/object_manipulator/puller.php
@@ -63,12 +63,12 @@ class puller extends manipulator {
                        f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
-             LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
+            INNER JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
+                 WHERE f.filesize <= ?
+                       AND o.location = ?
               GROUP BY f.contenthash,
                        f.filesize,
-                       o.location
-                HAVING MAX(f.filesize) <= ?
-                       AND (o.location = ?)';
+                       o.location';
 
         return $sql;
     }

--- a/classes/local/object_manipulator/pusher.php
+++ b/classes/local/object_manipulator/pusher.php
@@ -79,12 +79,12 @@ class pusher extends manipulator {
                        f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
-             LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
-                  WHERE f.filesize > :threshold
-                        AND f.filesize < :maximum_file_size
-                        AND f.timecreated <= :maxcreatedtimstamp
-                        AND (o.location IS NULL OR o.location = :object_location)
-               GROUP BY f.contenthash, o.location';
+            INNER JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
+                 WHERE f.filesize > :threshold
+                       AND f.filesize < :maximum_file_size
+                       AND f.timecreated <= :maxcreatedtimstamp
+                       AND o.location = :object_location
+              GROUP BY f.contenthash, o.location';
 
         return $sql;
     }

--- a/classes/local/object_manipulator/pusher.php
+++ b/classes/local/object_manipulator/pusher.php
@@ -27,8 +27,6 @@ namespace tool_objectfs\local\object_manipulator;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
-
 class pusher extends manipulator {
 
     /**
@@ -79,11 +77,11 @@ class pusher extends manipulator {
                        f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
-            INNER JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
+                  JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
                  WHERE f.filesize > :threshold
-                       AND f.filesize < :maximum_file_size
-                       AND f.timecreated <= :maxcreatedtimstamp
-                       AND o.location = :object_location
+                   AND f.filesize < :maximum_file_size
+                   AND f.timecreated <= :maxcreatedtimstamp
+                   AND o.location = :object_location
               GROUP BY f.contenthash, o.location';
 
         return $sql;

--- a/classes/local/object_manipulator/pusher.php
+++ b/classes/local/object_manipulator/pusher.php
@@ -99,7 +99,9 @@ class pusher extends manipulator {
     }
 
     protected function manipulate_object($objectrecord) {
-        $newlocation = $this->filesystem->copy_object_from_local_to_external_by_hash($objectrecord->contenthash, $objectrecord->filesize);
+        $contenthash = $objectrecord->contenthash;
+        $filesize = $objectrecord->filesize;
+        $newlocation = $this->filesystem->copy_object_from_local_to_external_by_hash($contenthash, $filesize);
         return $newlocation;
     }
 

--- a/classes/local/object_manipulator/recoverer.php
+++ b/classes/local/object_manipulator/recoverer.php
@@ -27,8 +27,6 @@ namespace tool_objectfs\local\object_manipulator;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
-
 class recoverer extends manipulator {
 
     /**
@@ -55,7 +53,7 @@ class recoverer extends manipulator {
                        f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
-            INNER JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
+                  JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
                  WHERE o.location = ?
               GROUP BY f.contenthash,
                        f.filesize,

--- a/classes/local/object_manipulator/recoverer.php
+++ b/classes/local/object_manipulator/recoverer.php
@@ -55,7 +55,7 @@ class recoverer extends manipulator {
                        f.contenthash,
                        MAX(f.filesize) AS filesize
                   FROM {files} f
-             LEFT JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
+            INNER JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
                  WHERE o.location = ?
               GROUP BY f.contenthash,
                        f.filesize,

--- a/classes/local/report/objectfs_report.php
+++ b/classes/local/report/objectfs_report.php
@@ -62,9 +62,11 @@ class objectfs_report implements \renderable {
         global $DB, $CFG;
 
         if ($CFG->branch <= 26) {
-            $lastruntime = $DB->get_field('config_plugins', 'value', array('name' => 'lastcron', 'plugin' => 'tool_objectfs'));
+            $lastruntime = $DB->get_field('config_plugins', 'value',
+                array('name' => 'lastcron', 'plugin' => 'tool_objectfs'));
         } else {
-            $lastruntime = $DB->get_field('task_scheduled', 'lastruntime', array('classname' => '\tool_objectfs\task\generate_status_report'));
+            $lastruntime = $DB->get_field('task_scheduled', 'lastruntime',
+                array('classname' => '\tool_objectfs\task\generate_status_report'));
         }
 
         return $lastruntime;

--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -716,4 +716,35 @@ abstract class object_file_system extends \file_system_filedir {
     public function supports_xsendfile() {
         return true;
     }
+
+    /**
+     * Add the supplied file to the file system and update its location.
+     *
+     * @param string $pathname Path to file currently on disk
+     * @param string $contenthash SHA1 hash of content if known (performance only)
+     * @return array (contenthash, filesize, newfile)
+     */
+    public function add_file_from_path($pathname, $contenthash = null) {
+        $result = parent::add_file_from_path($pathname, $contenthash);
+
+        $location = $this->get_object_location_from_hash($result[0]);
+        update_object_record($result[0], $location);
+
+        return $result;
+    }
+
+    /**
+     * Add a file with the supplied content to the file system and update its location.
+     *
+     * @param string $content file content - binary string
+     * @return array (contenthash, filesize, newfile)
+     */
+    public function add_file_from_string($content) {
+        $result = parent::add_file_from_string($content);
+
+        $location = $this->get_object_location_from_hash($result[0]);
+        update_object_record($result[0], $location);
+
+        return $result;
+    }
 }

--- a/classes/task/check_objects_location.php
+++ b/classes/task/check_objects_location.php
@@ -15,18 +15,39 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version information.
+ * Task that adds missing objects locations.
  *
  * @package   tool_objectfs
- * @author    Kenneth Hendricks <kennethhendricks@catalyst-au.net>
+ * @author    Mikhail Golenkov <mikhailgolenkov@catalyst-au.net>
  * @copyright Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace tool_objectfs\task;
+
+use tool_objectfs\local\object_manipulator\manipulator;
+
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2019082601;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2019082601;      // Same as version
-$plugin->requires  = 2013111811;      // Requires Filesystem API.
-$plugin->component = "tool_objectfs";
-$plugin->maturity  = MATURITY_STABLE;
+require_once( __DIR__ . '/../../lib.php');
+require_once(__DIR__ . '/../../../../../config.php');
+require_once($CFG->libdir . '/filestorage/file_system.php');
+
+class check_objects_location extends \core\task\scheduled_task {
+
+    /**
+     * Get task name
+     */
+    public function get_name() {
+        return get_string('check_objects_location_task', 'tool_objectfs');
+    }
+
+    /**
+     * Execute task
+     */
+    public function execute() {
+        manipulator::setup_and_run_object_manipulator('\\tool_objectfs\\local\\object_manipulator\\checker');
+    }
+}
+
+

--- a/classes/task/check_objects_location.php
+++ b/classes/task/check_objects_location.php
@@ -29,8 +29,6 @@ use tool_objectfs\local\object_manipulator\manipulator;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once( __DIR__ . '/../../lib.php');
-require_once(__DIR__ . '/../../../../../config.php');
 require_once($CFG->libdir . '/filestorage/file_system.php');
 
 class check_objects_location extends \core\task\scheduled_task {

--- a/classes/task/delete_local_objects.php
+++ b/classes/task/delete_local_objects.php
@@ -29,8 +29,6 @@ use tool_objectfs\local\object_manipulator\manipulator;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once( __DIR__ . '/../../lib.php');
-require_once(__DIR__ . '/../../../../../config.php');
 require_once($CFG->libdir . '/filestorage/file_system.php');
 
 class delete_local_objects extends \core\task\scheduled_task {

--- a/classes/task/generate_status_report.php
+++ b/classes/task/generate_status_report.php
@@ -30,7 +30,7 @@ use tool_objectfs\local\report\objectfs_report;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once( __DIR__ . '/../../lib.php');
+require_once(__DIR__ . '/../../lib.php');
 
 class generate_status_report extends \core\task\scheduled_task {
 

--- a/classes/task/pull_objects_from_storage.php
+++ b/classes/task/pull_objects_from_storage.php
@@ -29,8 +29,6 @@ use tool_objectfs\local\object_manipulator\manipulator;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once( __DIR__ . '/../../lib.php');
-require_once(__DIR__ . '/../../../../../config.php');
 require_once($CFG->libdir . '/filestorage/file_system.php');
 
 class pull_objects_from_storage extends \core\task\scheduled_task {

--- a/classes/task/push_objects_to_storage.php
+++ b/classes/task/push_objects_to_storage.php
@@ -29,8 +29,6 @@ use tool_objectfs\local\object_manipulator\manipulator;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once( __DIR__ . '/../../lib.php');
-require_once(__DIR__ . '/../../../../../config.php');
 require_once($CFG->libdir . '/filestorage/file_system.php');
 
 class push_objects_to_storage extends \core\task\scheduled_task {

--- a/classes/task/recover_error_objects.php
+++ b/classes/task/recover_error_objects.php
@@ -29,8 +29,6 @@ use tool_objectfs\local\object_manipulator\manipulator;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once( __DIR__ . '/../../lib.php');
-require_once(__DIR__ . '/../../../../../config.php');
 require_once($CFG->libdir . '/filestorage/file_system.php');
 
 class recover_error_objects extends \core\task\scheduled_task {

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -71,5 +71,14 @@ $tasks = array(
         'dayofweek' => '*',
         'month'     => '*'
     ),
+    array(
+        'classname' => 'tool_objectfs\task\check_objects_location',
+        'blocking'  => 0,
+        'minute'    => '7',
+        'hour'      => '*',
+        'day'       => '*',
+        'dayofweek' => '*',
+        'month'     => '*'
+    ),
 );
 

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -74,7 +74,7 @@ $tasks = array(
     array(
         'classname' => 'tool_objectfs\task\check_objects_location',
         'blocking'  => 0,
-        'minute'    => '7',
+        'minute'    => 'R',
         'hour'      => '*',
         'day'       => '*',
         'dayofweek' => '*',

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@
 use tool_objectfs\local\form\settings_form;
 
 require_once(__DIR__ . '/../../../config.php');
-require_once( __DIR__ . '/lib.php');
+require_once(__DIR__ . '/lib.php');
 require_once($CFG->libdir.'/adminlib.php');
 
 admin_externalpage_setup('tool_objectfs_settings');

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -30,6 +30,7 @@ $string['push_objects_to_storage_task'] = 'Object file system upload task';
 $string['delete_local_objects_task'] = 'Object file system delete local objects task';
 $string['pull_objects_from_storage_task'] = 'Object file system download objects task';
 $string['recover_error_objects_task'] = 'Object error recovery task';
+$string['check_objects_location_task'] = 'Object file system check objects location task';
 
 $string['generate_status_report_task'] = 'Object status report generator task';
 $string['not_enabled'] = 'The object file system background tasks are not enabled. No objects will move location until you do.';

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -133,6 +133,7 @@ $string['settings:preferexternal'] = 'Prefer external objects';
 $string['settings:preferexternal_help'] = 'If a file is stored both locally and in external object storage, read from external\. This is setting is mainly for testing purposes and introduces overhead to check the location.';
 
 $string['settings:presignedurl:header'] = 'Pre-Signed URLs Settings';
+$string['settings:presignedurl:warning'] = 'Before enabling Pre-Signed URL, please, make sure that all tests are passed successfully: ';
 $string['settings:presignedurl:enablepresignedurls'] = 'Enable Pre-Signed URLs';
 $string['settings:presignedurl:enablepresignedurls_help'] = 'Enable Pre-Signed URLs to request content directly from external storage.';
 $string['settings:presignedurl:expirationtime'] = 'Pre-Signed URL expiration time';

--- a/lib.php
+++ b/lib.php
@@ -92,19 +92,19 @@ function get_objectfs_config() {
     $config->expirationtime = 10 * MINSECS;
     $config->presignedminfilesize = 1024 * 50;
 
-    // '\tool_objectfs\s3_file_system'
+    // S3 file system.
     $config->s3_key = '';
     $config->s3_secret = '';
     $config->s3_bucket = '';
     $config->s3_region = 'us-east-1';
 
-    // '\tool_objectfs\do_file_system'
+    // Digital ocean file system.
     $config->do_key = '';
     $config->do_secret = '';
     $config->do_space = '';
     $config->do_region = 'sfo2';
 
-    // '\tool_objectfs\azure_file_system'
+    // Azure file system.
     $config->azure_accountname = '';
     $config->azure_container = '';
     $config->azure_sastoken = '';

--- a/missing_files.php
+++ b/missing_files.php
@@ -24,7 +24,7 @@
  */
 
 require_once(__DIR__ . '/../../../config.php');
-require_once( __DIR__ . '/lib.php');
+require_once(__DIR__ . '/lib.php');
 require_once($CFG->libdir.'/adminlib.php');
 
 use tool_objectfs\local\table\files_table;

--- a/object_status.php
+++ b/object_status.php
@@ -24,7 +24,7 @@
  */
 
 require_once(__DIR__ . '/../../../config.php');
-require_once( __DIR__ . '/lib.php');
+require_once(__DIR__ . '/lib.php');
 require_once($CFG->libdir.'/adminlib.php');
 
 use tool_objectfs\local\report\objectfs_report;

--- a/presignedurl_tests.php
+++ b/presignedurl_tests.php
@@ -24,7 +24,7 @@
  */
 
 require_once(__DIR__ . '/../../../config.php');
-require_once( __DIR__ . '/lib.php');
+require_once(__DIR__ . '/lib.php');
 require_once($CFG->libdir.'/adminlib.php');
 
 admin_externalpage_setup('tool_objectfs_presignedurl_testing');

--- a/presignedurl_tests.php
+++ b/presignedurl_tests.php
@@ -36,7 +36,8 @@ echo $output->heading(get_string('presignedurl_testing:page', 'tool_objectfs'));
 
 $config = get_objectfs_config();
 $support = tool_objectfs_filesystem_supports_presigned_urls($config->filesystem);
-$settingslink = \html_writer::link(new \moodle_url('/admin/tool/objectfs/index.php'), get_string('presignedurl_testing:objectfssettings', 'tool_objectfs'));
+$settingslink = \html_writer::link(new \moodle_url('/admin/tool/objectfs/index.php'),
+    get_string('presignedurl_testing:objectfssettings', 'tool_objectfs'));
 
 if ($support) {
 

--- a/renderer.php
+++ b/renderer.php
@@ -266,7 +266,8 @@ class tool_objectfs_renderer extends plugin_renderer_base {
         $output .= $this->box('');
         $output .= $this->heading(get_string('presignedurl_testing:test3', 'tool_objectfs'), 4);
         foreach ($testfiles as $file) {
-            $headers = array('Content-Disposition: inline; filename="'.$file->get_filename().'"', 'Content-Type: '.$file->get_mimetype());
+            $headers = array('Content-Disposition: inline; filename="'.$file->get_filename().
+                '"', 'Content-Type: '.$file->get_mimetype());
             $presignedurl = $fs->generate_presigned_url_to_external_file($file->get_contenthash(), $headers);
 
             $outputstring = get_string('presignedurl_testing:openinbrowser', 'tool_objectfs').': '.
@@ -277,7 +278,8 @@ class tool_objectfs_renderer extends plugin_renderer_base {
         $output .= $this->box('');
         $output .= $this->heading(get_string('presignedurl_testing:test4', 'tool_objectfs'), 4);
         foreach ($testfiles as $file) {
-            $headers = array('Content-Disposition: inline; filename="'.$file->get_filename().'"', 'Content-Type: '.$file->get_mimetype());
+            $headers = array('Content-Disposition: inline; filename="'.$file->get_filename().
+                '"', 'Content-Type: '.$file->get_mimetype());
             $presignedurl = $fs->generate_presigned_url_to_external_file($file->get_contenthash(), $headers);
 
             $outputstring = '"'.$file->get_filename().'" '.get_string('presignedurl_testing:fileiniframe', 'tool_objectfs').':';

--- a/tests/checker_test.php
+++ b/tests/checker_test.php
@@ -1,0 +1,111 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\tests;
+
+defined('MOODLE_INTERNAL') || die();
+
+use tool_objectfs\local\object_manipulator\checker;
+
+require_once(__DIR__ . '/classes/test_client.php');
+require_once(__DIR__ . '/tool_objectfs_testcase.php');
+
+class checker_testcase extends tool_objectfs_testcase {
+
+    protected function setUp() {
+        parent::setUp();
+        $config = get_objectfs_config();
+        // $config->sizethreshold = 100;
+        set_objectfs_config($config);
+        $this->logger = new \tool_objectfs\log\aggregate_logger();
+        $this->checker = new checker($this->filesystem, $config, $this->logger);
+        ob_start();
+    }
+
+    protected function tearDown() {
+        ob_end_clean();
+    }
+
+    public function test_checker_get_location_local_if_object_is_local() {
+        global $DB;
+        $file = $this->create_local_object();
+        $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
+        $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+
+        $this->assertEquals(OBJECT_LOCATION_LOCAL, $fslocation);
+        $this->assertEquals(OBJECT_LOCATION_LOCAL, $dblocation);
+        $this->assertIsNotBool($dblocation);
+    }
+
+    public function test_checker_get_location_duplicated_if_object_is_duplicated() {
+        global $DB;
+        $file = $this->create_duplicated_object();
+        $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
+        $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+
+        $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $fslocation);
+        $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $dblocation);
+        $this->assertIsNotBool($dblocation);
+    }
+
+    public function test_checker_get_location_external_if_object_is_external() {
+        global $DB;
+        $file = $this->create_remote_object();
+        $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
+        $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+
+        $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $fslocation);
+        $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $dblocation);
+        $this->assertIsNotBool($dblocation);
+    }
+
+    public function test_checker_get_candidate_objects_will_not_get_objects() {
+        $localobject = $this->create_local_object();
+        $remoteobject = $this->create_remote_object();
+        $duplicatedbject = $this->create_duplicated_object();
+        $candidateobjects = $this->checker->get_candidate_objects();
+
+        $this->assertArrayNotHasKey($localobject->contenthash, $candidateobjects);
+        $this->assertArrayNotHasKey($remoteobject->contenthash, $candidateobjects);
+        $this->assertArrayNotHasKey($duplicatedbject->contenthash, $candidateobjects);
+        $this->assertCount(0, $candidateobjects);
+    }
+
+    public function test_checker_get_candidate_objects_will_get_object() {
+        global $DB;
+        $localobject = $this->create_local_object();
+        $DB->delete_records('tool_objectfs_objects', array('contenthash' => $localobject->contenthash));
+        $candidateobjects = $this->checker->get_candidate_objects();
+
+        $this->assertNotCount(0, $candidateobjects);
+        foreach ($candidateobjects as $candidate) {
+            $this->assertEquals($localobject->contenthash, $candidate->contenthash);
+        }
+    }
+
+    public function test_checker_can_update_object() {
+        global $DB;
+        $localobject = $this->create_local_object();
+        $DB->delete_records('tool_objectfs_objects', array('contenthash' => $localobject->contenthash));
+        $this->checker->execute(array($localobject));
+        $candidateobjects = $this->checker->get_candidate_objects();
+        $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $localobject->contenthash));
+
+        $this->assertCount(0, $candidateobjects);
+        $this->assertEquals(OBJECT_LOCATION_LOCAL, $dblocation);
+        $this->assertIsNotBool($dblocation);
+    }
+}

--- a/tests/checker_test.php
+++ b/tests/checker_test.php
@@ -75,6 +75,7 @@ class checker_testcase extends tool_objectfs_testcase {
     }
 
     public function test_checker_get_candidate_objects_will_not_get_objects() {
+        $this->delete_all_files_in_db();
         $localobject = $this->create_local_object();
         $remoteobject = $this->create_remote_object();
         $duplicatedbject = $this->create_duplicated_object();
@@ -88,6 +89,7 @@ class checker_testcase extends tool_objectfs_testcase {
 
     public function test_checker_get_candidate_objects_will_get_object() {
         global $DB;
+        $this->delete_all_files_in_db();
         $localobject = $this->create_local_object();
         $DB->delete_records('tool_objectfs_objects', array('contenthash' => $localobject->contenthash));
         $candidateobjects = $this->checker->get_candidate_objects();
@@ -100,6 +102,7 @@ class checker_testcase extends tool_objectfs_testcase {
 
     public function test_checker_can_update_object() {
         global $DB;
+        $this->delete_all_files_in_db();
         $localobject = $this->create_local_object();
         $DB->delete_records('tool_objectfs_objects', array('contenthash' => $localobject->contenthash));
         $this->checker->execute(array($localobject));
@@ -153,9 +156,8 @@ class checker_testcase extends tool_objectfs_testcase {
         $this->assertTrue($resulttype);
     }
 
-    public function test_checker_manipulate_object_method_will_get_error_on_fake_file() {
-        $file = $this->create_local_object();
-        $file->contenthash = 'This is a fake contenthash';
+    public function test_checker_manipulate_object_method_will_get_error_location_on_error_file() {
+        $file = $this->create_error_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
         $result = $reflection->invokeArgs($this->checker, array($file));

--- a/tests/checker_test.php
+++ b/tests/checker_test.php
@@ -28,7 +28,6 @@ class checker_testcase extends tool_objectfs_testcase {
     protected function setUp() {
         parent::setUp();
         $config = get_objectfs_config();
-        // $config->sizethreshold = 100;
         set_objectfs_config($config);
         $this->logger = new \tool_objectfs\log\aggregate_logger();
         $this->checker = new checker($this->filesystem, $config, $this->logger);
@@ -44,10 +43,11 @@ class checker_testcase extends tool_objectfs_testcase {
         $file = $this->create_local_object();
         $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
         $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $dbrecord = gettype($dblocation) == 'string' ? true : false;
 
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $fslocation);
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $dblocation);
-        $this->assertIsNotBool($dblocation);
+        $this->assertTrue($dbrecord);
     }
 
     public function test_checker_get_location_duplicated_if_object_is_duplicated() {
@@ -55,10 +55,11 @@ class checker_testcase extends tool_objectfs_testcase {
         $file = $this->create_duplicated_object();
         $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
         $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $dbrecord = gettype($dblocation) == 'string' ? true : false;
 
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $fslocation);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $dblocation);
-        $this->assertIsNotBool($dblocation);
+        $this->assertTrue($dbrecord);
     }
 
     public function test_checker_get_location_external_if_object_is_external() {
@@ -66,10 +67,11 @@ class checker_testcase extends tool_objectfs_testcase {
         $file = $this->create_remote_object();
         $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
         $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $dbrecord = gettype($dblocation) == 'string' ? true : false;
 
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $fslocation);
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $dblocation);
-        $this->assertIsNotBool($dblocation);
+        $this->assertTrue($dbrecord);
     }
 
     public function test_checker_get_candidate_objects_will_not_get_objects() {

--- a/tests/pusher_test.php
+++ b/tests/pusher_test.php
@@ -156,7 +156,7 @@ class pusher_testcase extends tool_objectfs_testcase {
 
     public function test_get_candidate_objects_get_one_object_if_files_have_same_hash_different_mimetype() {
         global $DB;
-        // Push initial objects so they arnt candidates
+        // Push initial objects so they arnt candidates.
         $objects = $this->pusher->get_candidate_objects();
         $this->pusher->execute($objects);
 

--- a/tests/tasks_test.php
+++ b/tests/tasks_test.php
@@ -57,7 +57,8 @@ class tasks_testcase extends tool_objectfs_testcase {
                                     'generate_status_report',
                                     'pull_objects_from_storage',
                                     'push_objects_to_storage',
-                                    'recover_error_objects');
+                                    'recover_error_objects',
+                                    'check_objects_location');
 
         foreach ($scheduledtasknames as $taskname) {
             $task = \core\task\manager::get_scheduled_task('\\tool_objectfs\\task\\' . $taskname);

--- a/tests/tool_objectfs_testcase.php
+++ b/tests/tool_objectfs_testcase.php
@@ -60,8 +60,6 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
         // Above method does not set a file size, we do this it has a positive filesize.
         $DB->set_field('files', 'filesize', 10, array('contenthash' => $file->get_contenthash()));
 
-        update_object_record($file->get_contenthash(), OBJECT_LOCATION_LOCAL);
-
         return $file;
     }
 
@@ -87,7 +85,6 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
         // Above method does not set a file size, we do this it has a positive filesize.
         $DB->set_field('files', 'filesize', 10, array('contenthash' => $file->get_contenthash()));
 
-        update_object_record($file->get_contenthash(), OBJECT_LOCATION_LOCAL);
         return $file;
     }
 

--- a/tests/tool_objectfs_testcase.php
+++ b/tests/tool_objectfs_testcase.php
@@ -149,7 +149,7 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
     }
 
     protected function rename_file($currentpath, $destinationpath) {
-        $reflection = new \ReflectionMethod(object_file_system::class, 'delete_file');
+        $reflection = new \ReflectionMethod(object_file_system::class, 'rename_file');
         $reflection->setAccessible(true);
         return $reflection->invokeArgs($this->filesystem, [$currentpath, $destinationpath]);
     }
@@ -230,6 +230,12 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
     protected function delete_draft_files($contenthash) {
         global $DB;
         $DB->delete_records('files', array('contenthash' => $contenthash));
+    }
+
+    protected function delete_all_files_in_db() {
+        global $DB;
+        $DB->delete_records('files');
+        $DB->delete_records('tool_objectfs_objects');
     }
 
     protected function is_externally_readable_by_url($url) {


### PR DESCRIPTION
On big sites, cron tasks take a long time to complete and uses a lot of resources todo so.
This is because they use _left join_ and _is not NULL_ condition. 
Same query, but with inner join and without _is not NULL_ condition works much faster.

What should be implemented:
- [ ] Add a record to _tool_objectfs_objects_ table when new file created;
- [ ] Amend SQLs to use _inner join_ and remove _o.location is NULL_ condition;
- [ ] Add new cron task that would check files that do not exist in _tool_objectfs_objects_ and add them with current location.