### PR TITLE
Improve `check` tasks tests and fix Issue 178 

### DIFF
--- a/tests/checker_test.php
+++ b/tests/checker_test.php
@@ -41,34 +41,25 @@ class checker_testcase extends tool_objectfs_testcase {
     public function test_checker_get_location_local_if_object_is_local() {
         global $DB;
         $file = $this->create_local_object();
-        $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
-        $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
-
-        $this->assertNotFalse($dblocation);
-        $this->assertEquals(OBJECT_LOCATION_LOCAL, $fslocation);
-        $this->assertEquals(OBJECT_LOCATION_LOCAL, $dblocation);
+        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $this->assertNotFalse($location);
+        $this->assertEquals(OBJECT_LOCATION_LOCAL, $location);
     }
 
     public function test_checker_get_location_duplicated_if_object_is_duplicated() {
         global $DB;
         $file = $this->create_duplicated_object();
-        $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
-        $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
-
-        $this->assertNotFalse($dblocation);
-        $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $fslocation);
-        $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $dblocation);
+        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $this->assertNotFalse($location);
+        $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
     }
 
     public function test_checker_get_location_external_if_object_is_external() {
         global $DB;
         $file = $this->create_remote_object();
-        $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
-        $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
-
-        $this->assertNotFalse($dblocation);
-        $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $fslocation);
-        $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $dblocation);
+        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $this->assertNotFalse($location);
+        $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
     }
 
     public function test_checker_get_candidate_objects_will_not_get_objects() {

--- a/tests/checker_test.php
+++ b/tests/checker_test.php
@@ -63,43 +63,37 @@ class checker_testcase extends tool_objectfs_testcase {
     }
 
     public function test_checker_get_candidate_objects_will_not_get_objects() {
-        $this->delete_all_files_in_db();
-        $localobject = $this->create_local_object();
-        $remoteobject = $this->create_remote_object();
-        $duplicatedbject = $this->create_duplicated_object();
+        $localobject = $this->create_local_object('test_checker_get_candidate_objects_will_not_get_objects_local');
+        $remoteobject = $this->create_remote_object('test_checker_get_candidate_objects_will_not_get_objects_remote');
+        $duplicatedbject = $this->create_duplicated_object('test_checker_get_candidate_objects_will_not_get_objects_duplicated');
         $candidateobjects = $this->checker->get_candidate_objects();
 
         $this->assertArrayNotHasKey($localobject->contenthash, $candidateobjects);
         $this->assertArrayNotHasKey($remoteobject->contenthash, $candidateobjects);
         $this->assertArrayNotHasKey($duplicatedbject->contenthash, $candidateobjects);
-        $this->assertCount(0, $candidateobjects);
     }
 
     public function test_checker_get_candidate_objects_will_get_object() {
         global $DB;
-        $this->delete_all_files_in_db();
-        $localobject = $this->create_local_object();
+        $localobject = $this->create_local_object('test_checker_get_candidate_objects_will_get_object');
         $DB->delete_records('tool_objectfs_objects', array('contenthash' => $localobject->contenthash));
         $candidateobjects = $this->checker->get_candidate_objects();
 
         $this->assertNotCount(0, $candidateobjects);
-        foreach ($candidateobjects as $candidate) {
-            $this->assertEquals($localobject->contenthash, $candidate->contenthash);
-        }
+        $this->assertArrayHasKey($localobject->contenthash, $candidateobjects);
     }
 
     public function test_checker_can_update_object() {
         global $DB;
-        $this->delete_all_files_in_db();
-        $localobject = $this->create_local_object();
+        $localobject = $this->create_local_object('test_checker_can_update_object');
         $DB->delete_records('tool_objectfs_objects', array('contenthash' => $localobject->contenthash));
         $this->checker->execute(array($localobject));
         $candidateobjects = $this->checker->get_candidate_objects();
         $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $localobject->contenthash));
 
         $this->assertNotFalse($dblocation);
-        $this->assertCount(0, $candidateobjects);
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $dblocation);
+        $this->assertArrayNotHasKey($localobject->contenthash, $candidateobjects);
     }
 
     public function test_checker_get_candidates_sql_params_method_will_get_empty_array() {

--- a/tests/checker_test.php
+++ b/tests/checker_test.php
@@ -43,11 +43,10 @@ class checker_testcase extends tool_objectfs_testcase {
         $file = $this->create_local_object();
         $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
         $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
-        $dblocationtype = gettype($dblocation) == 'string' ? true : false;
 
+        $this->assertNotFalse($dblocation);
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $fslocation);
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $dblocation);
-        $this->assertTrue($dblocationtype);
     }
 
     public function test_checker_get_location_duplicated_if_object_is_duplicated() {
@@ -55,11 +54,10 @@ class checker_testcase extends tool_objectfs_testcase {
         $file = $this->create_duplicated_object();
         $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
         $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
-        $dblocationtype = gettype($dblocation) == 'string' ? true : false;
 
+        $this->assertNotFalse($dblocation);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $fslocation);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $dblocation);
-        $this->assertTrue($dblocationtype);
     }
 
     public function test_checker_get_location_external_if_object_is_external() {
@@ -67,11 +65,10 @@ class checker_testcase extends tool_objectfs_testcase {
         $file = $this->create_remote_object();
         $fslocation = $this->filesystem->get_object_location_from_hash($file->contenthash);
         $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
-        $dblocationtype = gettype($dblocation) == 'string' ? true : false;
 
+        $this->assertNotFalse($dblocation);
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $fslocation);
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $dblocation);
-        $this->assertTrue($dblocationtype);
     }
 
     public function test_checker_get_candidate_objects_will_not_get_objects() {
@@ -108,11 +105,10 @@ class checker_testcase extends tool_objectfs_testcase {
         $this->checker->execute(array($localobject));
         $candidateobjects = $this->checker->get_candidate_objects();
         $dblocation = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $localobject->contenthash));
-        $dblocationtype = gettype($dblocation) == 'string' ? true : false;
 
+        $this->assertNotFalse($dblocation);
         $this->assertCount(0, $candidateobjects);
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $dblocation);
-        $this->assertTrue($dblocationtype);
     }
 
     public function test_checker_get_candidates_sql_params_method_will_get_empty_array() {
@@ -127,43 +123,27 @@ class checker_testcase extends tool_objectfs_testcase {
         $file = $this->create_local_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $result = $reflection->invokeArgs($this->checker, array($file));
-        $resulttype = gettype($result) == 'integer' ? true : false;
-
-        $this->assertEquals(OBJECT_LOCATION_LOCAL, $result);
-        $this->assertTrue($resulttype);
+        $this->assertEquals(OBJECT_LOCATION_LOCAL, $reflection->invokeArgs($this->checker, array($file)));
     }
 
     public function test_checker_manipulate_object_method_will_get_correct_location_if_file_is_duplicated() {
         $file = $this->create_duplicated_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $result = $reflection->invokeArgs($this->checker, array($file));
-        $resulttype = gettype($result) == 'integer' ? true : false;
-
-        $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $result);
-        $this->assertTrue($resulttype);
+        $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $reflection->invokeArgs($this->checker, array($file)));
     }
 
     public function test_checker_manipulate_object_method_will_get_correct_location_if_file_is_external() {
         $file = $this->create_remote_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $result = $reflection->invokeArgs($this->checker, array($file));
-        $resulttype = gettype($result) == 'integer' ? true : false;
-
-        $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $result);
-        $this->assertTrue($resulttype);
+        $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $reflection->invokeArgs($this->checker, array($file)));
     }
 
     public function test_checker_manipulate_object_method_will_get_error_location_on_error_file() {
         $file = $this->create_error_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $result = $reflection->invokeArgs($this->checker, array($file));
-        $resulttype = gettype($result) == 'integer' ? true : false;
-
-        $this->assertEquals(OBJECT_LOCATION_ERROR, $result);
-        $this->assertTrue($resulttype);
+        $this->assertEquals(OBJECT_LOCATION_ERROR, $reflection->invokeArgs($this->checker, array($file)));
     }
 }

--- a/tests/tool_objectfs_testcase.php
+++ b/tests/tool_objectfs_testcase.php
@@ -232,12 +232,6 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
         $DB->delete_records('files', array('contenthash' => $contenthash));
     }
 
-    protected function delete_all_files_in_db() {
-        global $DB;
-        $DB->delete_records('files');
-        $DB->delete_records('tool_objectfs_objects');
-    }
-
     protected function is_externally_readable_by_url($url) {
         try {
             $file = fopen($url, 'r');


### PR DESCRIPTION
Remove unnecessary file system location checks.
Remove delete_all_files_in_db() method.
Fix for Issue #178 .