### PR TITLE
Digital ocean

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $CFG->alternative_file_system_class = '\tool_objectfs\azure_file_system';
 
 * DigitalOcean Spaces
 ```php
-$CFG->alternative_file_system_class = '\tool_objectfs\do_file_system';
+$CFG->alternative_file_system_class = '\tool_objectfs\digitalocean_file_system';
 ```
 
 

--- a/classes/digitalocean_file_system.php
+++ b/classes/digitalocean_file_system.php
@@ -28,6 +28,6 @@ defined('MOODLE_INTERNAL') || die();
 
 use tool_objectfs\local\store\digitalocean\file_system;
 
-class do_file_system extends file_system {
+class digitalocean_file_system extends file_system {
 
 }

--- a/classes/local/store/digitalocean/client.php
+++ b/classes/local/store/digitalocean/client.php
@@ -58,13 +58,12 @@ class client extends s3_client {
         $mform->addElement('header', 'doheader', get_string('settings:do:header', 'tool_objectfs'));
         $mform->setExpanded('doheader');
 
-        $mform = $this->define_amazon_s3_check($mform, false);
-
         $regionoptions = array(
             'sfo2'      => 'sfo2 (San Fransisco)',
             'nyc3'      => 'nyc3 (New York City)',
             'ams3'      => 'ams3 (Amsterdam)',
             'sgp1'      => 'spg1 (Singapore)',
+            'fra1'      => 'fra1 (Frankfurt)',
         );
 
         $mform->addElement('text', 'do_key', get_string('settings:do:key', 'tool_objectfs'));
@@ -81,6 +80,8 @@ class client extends s3_client {
 
         $mform->addElement('select', 'do_region', get_string('settings:do:region', 'tool_objectfs'), $regionoptions);
         $mform->addHelpButton('do_region', 'settings:do:region', 'tool_objectfs');
+
+        $mform = $this->define_amazon_s3_check($mform, false);
 
         return $mform;
     }

--- a/lib.php
+++ b/lib.php
@@ -133,7 +133,7 @@ function tool_objectfs_get_client($config) {
 function tool_objectfs_get_fs_list() {
     $found[''] = 'Please, select';
     $found['\tool_objectfs\azure_file_system'] = '\tool_objectfs\azure_file_system';
-    $found['\tool_objectfs\do_file_system'] = '\tool_objectfs\do_file_system';
+    $found['\tool_objectfs\digitalocean_file_system'] = '\tool_objectfs\digitalocean_file_system';
     $found['\tool_objectfs\s3_file_system'] = '\tool_objectfs\s3_file_system';
     $found['\tool_objectfs\swift_file_system'] = '\tool_objectfs\swift_file_system';
     return $found;


### PR DESCRIPTION
I just upgraded my Moodle instance to the latest master branch code. I use the DigitalOcean integration and upon installing I noticed that the plugin was no longer working. Did some debugging and found that since everything was restructured, the code was looking for files in a store/do directory rather than the new store/digitalocean directory.

This pull request fixed that reference and updates the readme to reflect the new digitalocean directory. While I was making changes, I also included the new Frankfrut region as an option.