### PR TITLE
Issue #226: Unit tests are failing checking empty directories

### DIFF
--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -291,7 +291,7 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         }
         $this->filesystem->delete_empty_dirs($testdir);
         foreach ($dirs as $key => $dir) {
-             $this->assertEquals($expectedparentreadable[$key], is_readable($testdir . $dir));
+            $this->assertEquals($expectedparentreadable[$key], is_readable($testdir . $dir));
         }
         $this->assertEquals($expectedgrandparentpathreadable, is_readable($testdir));
     }

--- a/tests/tool_objectfs_testcase.php
+++ b/tests/tool_objectfs_testcase.php
@@ -34,6 +34,17 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
         $this->resetAfterTest(true);
     }
 
+    protected function tearDown() {
+        $this->clear_file_dir();
+        parent::tearDown();
+    }
+
+    protected function clear_file_dir() {
+        global $CFG;
+        $filedir = $CFG->dataroot . '/filedir';
+        remove_dir($filedir);
+    }
+
     protected function reset_file_system() {
         $this->filesystem = new test_file_system();
     }


### PR DESCRIPTION
Needed to clear out old directory structures and recreate
according to test.