### PR TITLE
Test catalyst #231 - Test file for relative URLs

### DIFF
--- a/tests/fixtures/testindex.html
+++ b/tests/fixtures/testindex.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        <title>HTML test</title>
+    </head>
+    <body>
+        <img src="./testimage.png" />
+    </body>
+</html>


### PR DESCRIPTION
This is a patch to test S3 URL signing for file (e.g. SCORMS, etc...) with relative URLs. It currently fails.