### PR TITLE
Re-work presigned_url_should_redirect() method

### DIFF
--- a/classes/local/manager.php
+++ b/classes/local/manager.php
@@ -237,6 +237,20 @@ class manager {
     }
 
     /**
+     * Check if all file extensions are whitelisted.
+     *
+     * @return bool
+     * @throws \dml_exception
+     */
+    public static function all_extensions_whitelisted() {
+        $config = self::get_objectfs_config();
+        if (!empty($config->signingwhitelist) && $config->signingwhitelist == '*') {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Check if '$CFG->alternative_file_system_class' is properly set.
      * @return bool
      */

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -651,11 +651,13 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $provider[] = array(1, '', true);
         $provider[] = array(1, null, false);
 
-        // Testing minimum file size to be greater than file size = 10 (default).
+        // Testing minimum file size to be greater than file size = 10.
+        // 10 is a default file size created in objectfs unit tests.
         $provider[] = array(1, 11, false);
         $provider[] = array(1, '11', false);
 
-        // Testing minimum file size to be less than file size = 10 (default).
+        // Testing minimum file size to be less than file size = 10.
+        // 10 is a default file size created in objectfs unit tests.
         $provider[] = array(1, 9, true);
         $provider[] = array(1, '9', true);
 
@@ -692,6 +694,7 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         }
 
         $object = $this->create_local_object();
+        set_config('signingwhitelist', '*', 'tool_objectfs');
         $this->assertEquals($result, $this->filesystem->presigned_url_should_redirect($object->contenthash));
     }
 


### PR DESCRIPTION
This is a pull request fot #279 

1. Implement new manager method `all_extensions_whitelisted()`.
2. Always redirect when `presignedminfilesize` is set to `0` and all file extentions are whitelisted.
3. Otherwise, redirect when the file size is bigger than presignedminfilesize setting and the file extension is whitelisted.
4. Fix `test_presigned_url_should_redirect_provider()` unit test and set `signingwhitelist` to `*`, as all files created in this test have hash as their names.