### PR TITLE
Report: Show smaller divisions all the way down to 1kb

### DIFF
--- a/classes/local/report/log_size_report_builder.php
+++ b/classes/local/report/log_size_report_builder.php
@@ -59,8 +59,8 @@ class log_size_report_builder extends objectfs_report_builder {
 
         foreach ($stats as $key => $stat) {
 
-            // Logsize of <= 19 means that files are smaller than 1 MB.
-            if ($stat->datakey <= 19) {
+            // Logsize of <= 9 means that files are smaller than 1 KB.
+            if ($stat->datakey <= 9) {
                 $smallstats->objectcount += $stat->objectcount;
                 $smallstats->objectsum += $stat->objectsum;
                 unset($stats[$key]);

--- a/renderer.php
+++ b/renderer.php
@@ -148,7 +148,7 @@ class tool_objectfs_renderer extends plugin_renderer_base {
 
         // Small logsizes have been compressed.
         if ($logsize == 'small') {
-            return '< 1MB';
+            return '< 1KB';
         }
 
         $floor = pow(2, $logsize);


### PR DESCRIPTION
This is a fix for #309 