### PR TITLE
Fix broken URL on Pre-Signed URL testing page and lang string

### DIFF
--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -211,7 +211,7 @@ $string['settings:presignedcloudfronturl:cloudfront_pem_not_found'] = 'Cloudfron
 
 $string['pleaseselect'] = 'Please, select';
 $string['presignedurl_testing:page'] = 'Pre-Signed URL Testing';
-$string['presignedurl_testing:presignedurlsnotsupported'] = 'Pre-Signed URLa are not supported by chosen storage file system.';
+$string['presignedurl_testing:presignedurlsnotsupported'] = 'Pre-Signed URLs are not supported by chosen storage file system.';
 $string['presignedurl_testing:test1'] = '1) Test links below to download file with contenthash as its name:';
 $string['presignedurl_testing:test2'] = '2) Test links below to download file with original file name:';
 $string['presignedurl_testing:test3'] = '3) Test links below to open content inline:';

--- a/presignedurl_tests.php
+++ b/presignedurl_tests.php
@@ -44,7 +44,7 @@ if ($delete) {
 
 echo $output->header();
 echo $output->heading(get_string('presignedurl_testing:page', 'tool_objectfs'));
-$settingslink = \html_writer::link(new \moodle_url('/admin/settings.php?section=tool_objectfs'),
+$settingslink = \html_writer::link(new \moodle_url('/admin/settings.php?section=tool_objectfs_settings'),
     get_string('presignedurl_testing:objectfssettings', 'tool_objectfs'));
 
 $config = manager::get_objectfs_config();


### PR DESCRIPTION
An additional patch for #311 
- Fix the link that leads to Objectfs settings from Pre-Signed URL Testing page when Pre-Signed URLs are not supported by chosen storage file system.
- Fix lang string.