### PR TITLE
Throw exception if MDL-53240 is not backported

### DIFF
--- a/classes/local/manager.php
+++ b/classes/local/manager.php
@@ -225,11 +225,16 @@ class manager {
      * @param string $filename
      * @return bool
      * @throws \dml_exception
+     * @throws \coding_exception
      */
     public static function is_extension_whitelisted($filename) {
         $config = self::get_objectfs_config();
         if (empty($config->signingwhitelist)) {
             return false;
+        }
+        $classexists = class_exists('\core_form\filetypes_util');
+        if (!$classexists) {
+            throw new \coding_exception(get_string('backportfiletypesclass', 'tool_objectfs'));
         }
         $util = new \core_form\filetypes_util();
         $whitelist = $util->normalize_file_types($config->signingwhitelist);

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -245,3 +245,4 @@ $string['settings:testingdescr'] = 'This setting is mainly for testing purposes 
 
 $string['settings:error:numeric'] = 'Please enter a number which is greater than or equal 0.';
 $string['total_deleted_dirs'] = 'Total number of deleted directories: ';
+$string['backportfiletypesclass'] = 'Backport MDL-53240 is missing. Follow up https://github.com/catalyst/moodle-tool_objectfs#applying-core-patches';


### PR DESCRIPTION
This will facilitate error investigations like [this](https://github.com/catalyst/moodle-tool_objectfs/issues/294#issuecomment-654528606) (Issue #294 )