### PR TITLE
Implement additional check if the file is missing externally.

### DIFF
--- a/classes/local/store/object_client.php
+++ b/classes/local/store/object_client.php
@@ -44,6 +44,5 @@ interface object_client {
     public function test_permissions($testdelete);
     public function proxy_range_request(\stored_file $file, $ranges);
     public function test_range_request($filesystem);
+    public function is_file_readable_by_hash($contenthash);
 }
-
-

--- a/classes/local/store/object_client_base.php
+++ b/classes/local/store/object_client_base.php
@@ -161,4 +161,21 @@ abstract class object_client_base implements object_client {
     public function test_permissions($testdelete) {
         return (object)['success' => false, 'details' => ''];
     }
+
+    /**
+     * Checks if the file is readable externally by contenthash.
+     * Returns true if the file is readable.
+     * Returns false if the file is missing externally.
+     * Throws an exceptions if there is any other issue with external storage.
+     * Base method uses basic is_readable() function, but should be overridden
+     * in client class to figure out why exactly the file is not readable.
+     *
+     * @param string $contenthash File content hash.
+     * @return bool
+     * @throws \coding_exception
+     */
+    public function is_file_readable_by_hash($contenthash) {
+        $path = $this->get_fullpath_from_hash($contenthash);
+        return is_readable($path);
+    }
 }

--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -194,7 +194,15 @@ abstract class object_file_system extends \file_system_filedir {
         $path = $this->get_external_path_from_hash($contenthash, false);
 
         // Note - it is not possible to perform a content recovery safely from a hash alone.
-        return is_readable($path);
+        if (is_readable($path)) {
+            // File is readable externally, so everything is good here.
+            return true;
+        } else {
+            // Otherwise make a deeper check.
+            // This is needed to figure out if the file is simply missing externally or
+            // there is an issue with external storage.
+            return $this->externalclient->is_file_readable_by_hash($contenthash);
+        }
     }
 
     public function is_file_readable_externally_in_trash_by_hash($contenthash) {

--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -439,8 +439,8 @@ abstract class object_file_system extends \file_system_filedir {
             return $this->redirect_to_presigned_url($contenthash, headers_list());
         }
 
-        if ($this->externalclient->support_presigned_urls() &&
-                $ranges = $this->get_valid_http_ranges($file->get_filesize()) &&
+        $ranges = $this->get_valid_http_ranges($file->get_filesize());
+        if ($this->externalclient->support_presigned_urls() && !empty($ranges) &&
                 $this->is_file_readable_externally_by_hash($contenthash)) {
 
             return $this->externalclient->proxy_range_request($file, $ranges);


### PR DESCRIPTION
#375

The logic is
Use `is_readable()` to check if the file is readable externally.
In most cases it will be readable.
If it's not we make a deeper check which will:
     * Return `true` if the file is readable.
     * Return `false` if the file is missing externally.
     * Throw an exceptions if there is any other issue with external storage.