### PR TITLE
Enhance range requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ cache:
     - $HOME/.composer/cache
     - $HOME/.npm
 
-dist: trusty
+dist: xenial
+
+services:
+  - mysql
 
 addons:
-  postgresql: "9.5"
+  postgresql: "9.6"
 
 matrix:
   include:

--- a/classes/local/store/object_client_base.php
+++ b/classes/local/store/object_client_base.php
@@ -135,10 +135,10 @@ abstract class object_client_base implements object_client {
      * Test proxy range request.
      *
      * @param  object  $filesystem  Filesystem to be tested.
-     * @return bool
+     * @return object
      */
     public function test_range_request($filesystem) {
-        return false;
+        return (object)['result' => false, 'error' => ''];
     }
 
     /**

--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -431,8 +431,8 @@ abstract class object_file_system extends \file_system_filedir {
             return $this->redirect_to_presigned_url($contenthash, headers_list());
         }
 
-        if ($this->externalclient->support_presigned_urls() &&
-                $ranges = $this->get_valid_http_ranges($file->get_filesize()) &&
+        $ranges = $this->get_valid_http_ranges($file->get_filesize());
+        if ($this->externalclient->support_presigned_urls() && !empty($ranges) &&
                 $this->is_file_readable_externally_by_hash($contenthash)) {
 
             return $this->externalclient->proxy_range_request($file, $ranges);

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -50,6 +50,7 @@ $string['object_status:runningsize'] = 'Running total';
 $string['page:missingfiles'] = 'Missing from filedir and external storage files';
 
 $string['filename:missingfiles'] = 'missingfiles';
+$string['fixturefilemissing'] = 'The fixture file is missing';
 
 $string['object_status:location:error'] = 'Missing from filedir and external storage (<a href="/admin/tool/objectfs/missing_files.php">view files</a>)';
 $string['object_status:location:duplicated'] = 'Duplicated in filedir and external storage';
@@ -82,6 +83,7 @@ $string['object_status:filedir:update'] = 'Update stats';
 $string['object_status:last_run'] = 'This report was generated on {$a}';
 $string['object_status:never_run'] = 'The task to generate this report has not been run.';
 
+$string['rangerequestfailed'] = '<strong>URL</strong>: {$a->url}<br><strong>HTTP code</strong>: {$a->httpcode}<br><strong>Details</strong>: {$a->details}';
 $string['settings'] = 'Settings';
 $string['settings:enabletasks'] = 'Enable transfer tasks';
 $string['settings:enabletasks_help'] = 'Enable or disable the object file system tasks which move files between the filedir and external object storage.';
@@ -183,7 +185,7 @@ $string['settings:presignedurl:proxyrangerequests'] = 'Proxy range requests';
 $string['settings:presignedurl:proxyrangerequests_help'] = 'Pre-Signed URLs do not need to be enabled. S3 signing method will be used for this feature.';
 $string['settings:presignedurl:xsendfilefile'] = 'Backport MDL-68342 to get benefits of this setting.';
 $string['settings:presignedurl:testrangeok'] = 'Successfully tested range request.';
-$string['settings:presignedurl:testrangeerror'] = 'Test range request failed.';
+$string['settings:presignedurl:testrangeerror'] = 'Test range request failed';
 
 $string['settings:presignedurl:enablepresigneds3urls'] = 'S3 Pre-Signed URLs';
 $string['settings:presignedurl:enablepresigneds3urls_help'] = 'Enable Pre-Signed S3 URLs to request content directly from external storage.';

--- a/settings.php
+++ b/settings.php
@@ -158,11 +158,13 @@ if ($ADMIN->fulltree) {
                 $warningtext .= $OUTPUT->notification(get_string('settings:presignedurl:xsendfilefile', 'tool_objectfs'));
             } else if ($connstatus) {
                 // Range request tests can only work if there is a valid connection.
-                if ($client->test_range_request(new $config->filesystem())) {
+                $range = $client->test_range_request(new $config->filesystem());
+                if ($range->result) {
                     $warningtext .= $OUTPUT->notification(get_string('settings:presignedurl:testrangeok', 'tool_objectfs'),
                         'notifysuccess');
                 } else {
                     $warningtext .= $OUTPUT->notification(get_string('settings:presignedurl:testrangeerror', 'tool_objectfs'));
+                    $warningtext .= $OUTPUT->notification($range->error);
                 }
             }
             $settings->add(new admin_setting_configcheckbox('tool_objectfs/proxyrangerequests',

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -714,26 +714,32 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $now = time();
         return [
             // Default Pre-Signed URL expiration time and int-like 'Expires' header.
-            [7200, $now, 0, $now + 7200],
+            [7200, $now, 0, $now + 7200 + MINSECS],
             [7200, $now, $now - 100, $now + MINSECS],
+            [7200, $now, $now + 30, $now + MINSECS],
             [7200, $now, $now + 100, $now + 100],
             [7200, $now, $now + WEEKSECS + HOURSECS, $now + WEEKSECS - MINSECS],
 
             // Default Pre-Signed URL expiration time and string-like 'Expires' header.
-            [7200, $now, 'Thu, 01 Jan 1970 00:00:00 GMT', $now + 7200],
+            [7200, $now, 'Thu, 01 Jan 1970 00:00:00 GMT', $now + 7200 + MINSECS],
             [7200, $now, userdate($now - 100, '%a, %d %b %Y %H:%M:%S'), $now + MINSECS],
+            [7200, $now, userdate($now + 30, '%a, %d %b %Y %H:%M:%S'), $now + MINSECS],
             [7200, $now, userdate($now + 100, '%a, %d %b %Y %H:%M:%S'), $now + 100],
             [7200, $now, userdate($now + WEEKSECS + HOURSECS, '%a, %d %b %Y %H:%M:%S'), $now + WEEKSECS - MINSECS],
 
             // Custom Pre-Signed URL expiration time and int-like 'Expires' header.
-            [600, $now, 0, $now + 600],
+            [0, $now, 0, $now + MINSECS],
+            [600, $now, 0, $now + 600 + MINSECS],
             [600, $now, $now - 100, $now + MINSECS],
+            [600, $now, $now + 30, $now + MINSECS],
             [600, $now, $now + 100, $now + 100],
             [600, $now, $now + WEEKSECS + HOURSECS, $now + WEEKSECS - MINSECS],
 
             // Custom Pre-Signed URL expiration time and string-like 'Expires' header.
-            [600, $now, 'Thu, 01 Jan 1970 00:00:00 GMT', $now + 600],
+            [0, $now, 'Thu, 01 Jan 1970 00:00:00 GMT', $now + MINSECS],
+            [600, $now, 'Thu, 01 Jan 1970 00:00:00 GMT', $now + 600 + MINSECS],
             [600, $now, userdate($now - 100, '%a, %d %b %Y %H:%M:%S'), $now + MINSECS],
+            [600, $now, userdate($now + 30, '%a, %d %b %Y %H:%M:%S'), $now + MINSECS],
             [600, $now, userdate($now + 100, '%a, %d %b %Y %H:%M:%S'), $now + 100],
             [600, $now, userdate($now + WEEKSECS + HOURSECS, '%a, %d %b %Y %H:%M:%S'), $now + WEEKSECS - MINSECS],
         ];
@@ -869,9 +875,9 @@ class object_file_system_testcase extends tool_objectfs_testcase {
     public function test_test_range_request() {
         $externalclient = $this->filesystem->get_external_client();
         if ($externalclient->support_presigned_urls()) {
-            $this->assertTrue($externalclient->test_range_request($this->filesystem));
+            $this->assertTrue($externalclient->test_range_request($this->filesystem)->result);
         } else {
-            $this->assertFalse($externalclient->test_range_request($this->filesystem));
+            $this->assertFalse($externalclient->test_range_request($this->filesystem)->result);
         }
     }
 


### PR DESCRIPTION
Enhancements related to `get_expiration_time()`:
* When `$expires` is set to 0 or false (it can be false if an empty string passed to `strtotime()`) - set it to default + 1 min as a healthy margin.
* When `$expires` is already expired or is going to expire in a minute - set to 1 minute.
* Updated integration unit tests.

Enhancements related to `test_range_request()`:
* Pass 1 hour as an Expire header.
* `test_range_request()` now returns an object with `result` and `error` properties.
* Admin settings page now shows some extra details when test proxy request fails.
* Updated integration unit tests.

Enhancements related to `xsendfile_file()`:
* Move `get_valid_http_ranges()` out of `if` block. For some reason `$ranges` was equal to `true`, not to array with ranges.