### PR TITLE
If deletelocal is false, don't run empty dir cleanup either.

### DIFF
--- a/classes/task/delete_local_empty_directories.php
+++ b/classes/task/delete_local_empty_directories.php
@@ -26,6 +26,7 @@
 namespace tool_objectfs\task;
 
 use coding_exception;
+use tool_objectfs\local\manager;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -42,6 +43,11 @@ class delete_local_empty_directories  extends task {
      */
     public function execute() {
         if (!$this->enabled_tasks()) {
+            return;
+        }
+        // If config is set to not deletelocal objects, don't run directory clean up either.
+        $config = manager::get_objectfs_config();
+        if (!$config->deletelocal) {
             return;
         }
         $filesystem = new $this->config->filesystem();


### PR DESCRIPTION
Fix #400

I haven't tested this one locally yet, so might be best to hold off until someone (me probably) puts this on a local site and makes sure I've got the logic right :-)