### PR TITLE
fix: Add needed client options to work with digital ocean spaces

### DIFF
--- a/classes/local/store/digitalocean/client.php
+++ b/classes/local/store/digitalocean/client.php
@@ -35,9 +35,16 @@ class client extends s3_client {
         $this->autoloader = $CFG->dirroot . '/local/aws/sdk/aws-autoloader.php';
         $this->testdelete = false;
 
+
         if ($this->get_availability() && !empty($config)) {
             require_once($this->autoloader);
             $this->bucket = $config->do_space;
+            $this->maxupload = OBJECTFS_BYTES_IN_TERABYTE * 5;
+            $this->expirationtime = $config->expirationtime;
+            $this->presignedminfilesize = $config->presignedminfilesize;
+            $this->enablepresignedurls = $config->enablepresignedurls;
+            $this->signingmethod = $config->signingmethod;
+
             $this->set_client($config);
         } else {
             parent::__construct($config);

--- a/classes/local/store/digitalocean/client.php
+++ b/classes/local/store/digitalocean/client.php
@@ -35,7 +35,6 @@ class client extends s3_client {
         $this->autoloader = $CFG->dirroot . '/local/aws/sdk/aws-autoloader.php';
         $this->testdelete = false;
 
-
         if ($this->get_availability() && !empty($config)) {
             require_once($this->autoloader);
             $this->bucket = $config->do_space;


### PR DESCRIPTION
## Scenario

As stated in https://github.com/catalyst/moodle-tool_objectfs/issues/318, when we use the digital ocean spaces client, the diff for changed files isn't working properly.

Looking at the PR https://github.com/catalyst/moodle-tool_objectfs/pull/323, the real fix for this is really simple, so I made this PR to the minimal required change.

## What Has Been Done

- [x] Corrected DigitalOcean client setup.