### PR TITLE
Fix deprecated whitelist warning in M3.10

### DIFF
--- a/classes/local/manager.php
+++ b/classes/local/manager.php
@@ -242,7 +242,11 @@ class manager {
             return false;
         }
         $extension = strtolower('.' . pathinfo($filename, PATHINFO_EXTENSION));
-        return $util->is_whitelisted($extension, $whitelist);
+        if (method_exists($util, 'is_listed')) {
+            return $util->is_listed($extension, $whitelist);
+        } else {
+            return $util->is_whitelisted($extension, $whitelist);
+        }
     }
 
     /**


### PR DESCRIPTION
Fix deprecated warnings in Moodle 3.10 as is_whitelisted() has been deprecated in favour of is_listed().

I have included a check so this code still works on older versions of moodle.
(Sorry I was unsure on your policy of Moodle version support for this plugin - happy to just switch to the new function instead)