### PR TITLE
Issue423 missing files table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
       mariadb:
-        image: mariadb:10
+        image: mariadb:10.5
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"

--- a/classes/local/table/files_table.php
+++ b/classes/local/table/files_table.php
@@ -51,6 +51,7 @@ class files_table extends \table_sql {
             'filearea', 'filename', 'filepath', 'mimetype', 'filesize', 'timecreated'];
 
         $this->no_sorting('localpath');
+        $this->no_sorting('link');
 
         $this->define_columns($this->columns);
         $this->define_headers($this->headers);


### PR DESCRIPTION
As from #423, 

Without direct access to the database, it is cumbersome to identify the approximate location of the missing files with only the contextid and filename available.

A proposal is to add an additional column to the files_table class which can provide a link to the associated module, course, etc. This aids investigating where files have gone missing.