### PR TITLE
T12 Unit text fix, test_delete_empty_folders()

### DIFF
--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -294,6 +294,9 @@ class object_file_system_testcase extends tool_objectfs_testcase {
             $this->assertEquals($expectedparentreadable[$key], is_readable($testdir . $dir));
         }
         $this->assertEquals($expectedgrandparentpathreadable, is_readable($testdir));
+
+        // Totara 12 clean-up.
+        remove_dir($testdir);
     }
 
     public function test_readfile_if_object_is_local() {


### PR DESCRIPTION
During PHPUnit execution the sitedata folder is not cleaned up with this test on T12.
> tool_objectfs\tests\object_file_system_testcase::test_delete_empty_folders

