### PR TITLE
Digital Ocean Tweak to prevent PHP notice

### DIFF
--- a/classes/local/store/digitalocean/client.php
+++ b/classes/local/store/digitalocean/client.php
@@ -38,6 +38,7 @@ class client extends s3_client {
         if ($this->get_availability() && !empty($config)) {
             require_once($this->autoloader);
             $this->bucket = $config->do_space;
+            $this->bucketkeyprefix = "";
             $this->set_client($config);
         } else {
             parent::__construct($config);


### PR DESCRIPTION
Added bucketkeyprefix to fix PHP notice when using digital ocean (since it extends the S3 client)