### PR TITLE
Tidy up trash handling process for file deletes.

### DIFF
--- a/classes/local/store/azure/client.php
+++ b/classes/local/store/azure/client.php
@@ -106,17 +106,6 @@ class client extends object_client_base {
     }
 
     /**
-     * Returns azure trash fullpath to use with php file functions.
-     *
-     * @param  string $contenthash contenthash used as key in azure.
-     * @return string trash fullpath to azure object.
-     */
-    public function get_trash_fullpath_from_hash($contenthash) {
-        $filepath = $this->get_filepath_from_hash($contenthash);
-        return "blob://$this->container/trash/$filepath";
-    }
-
-    /**
      * Deletes file (blob) in azure blob storage.
      *
      * @param string $fullpath path to azure blob.

--- a/classes/local/store/object_client.php
+++ b/classes/local/store/object_client.php
@@ -29,7 +29,6 @@ interface object_client {
     public function __construct($config);
     public function register_stream_wrapper();
     public function get_fullpath_from_hash($contenthash);
-    public function get_trash_fullpath_from_hash($contenthash);
     public function delete_file($fullpath);
     public function rename_file($currentpath, $destinationpath);
     public function get_seekable_stream_context();

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -153,17 +153,6 @@ class client extends object_client_base {
     }
 
     /**
-     * Returns s3 trash fullpath to use with php file functions.
-     *
-     * @param  string $contenthash contenthash used as key in s3.
-     * @return string trash fullpath to s3 object.
-     */
-    public function get_trash_fullpath_from_hash($contenthash) {
-        $filepath = $this->get_filepath_from_hash($contenthash);
-        return "s3://$this->bucket/" . $this->bucketkeyprefix . "trash/$filepath";
-    }
-
-    /**
      * Deletes a file in S3 storage.
      *
      * @path   string full path to S3 file.

--- a/classes/local/store/swift/client.php
+++ b/classes/local/store/swift/client.php
@@ -320,19 +320,6 @@ class client extends object_client_base {
     }
 
     /**
-     * Returns swift trash fullpath to use with php file functions.
-     *
-     * @param string $contenthash contenthash used as key in swift.
-     * @return string
-     * @throws \Exception if fails
-     */
-    public function get_trash_fullpath_from_hash($contenthash) {
-        $container = $this->get_container();
-        $filepath = $this->get_filepath_from_hash($contenthash);
-        return "swift://$container->name/trash/$filepath";
-    }
-
-    /**
      * Returns relative path to blob from fullpath to use with php file functions.
      *
      * @param string $fullpath full path to azure blob.

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -173,7 +173,7 @@ $string['settings:minimumage'] = 'Minimum age';
 $string['settings:minimumage_help'] = 'Minimum age that a object must exist on the local filedir before it will be considered for transfer.';
 $string['settings:deleteexternal'] = 'Delete external objects';
 $string['settings:deleteexternal_help'] = 'Delete external objects when the file is deleted in Moodle. This is not recommended if you intend to share one object store between multiple environments, however this is a requirement for GDPR compliance.
-<br/>Send to trash - will send the file to the external storage trashdir (safest method).
+<br/>Delete external file on orphan clean-up - This will delete the external file when the delete orphaned metadata task task runs.
 <br/>Delete completely - will tell the external storage to delete the file immediately - (use with caution! - if the same file is being uploaded while being deleted issues could occur.)';
 $string['settings:deletelocal'] = 'Delete local objects';
 $string['settings:deletelocal_help'] = 'Delete local objects once they are in external object storage after the consistency delay.';
@@ -229,7 +229,7 @@ $string['settings:presignedcloudfronturl:cloudfront_custom_policy_json'] = '\'cu
 $string['settings:presignedcloudfronturl:cloudfront_custom_policy_json_help'] = 'AWS Distribution "custom policy" JSON (advanced!)';
 $string['settings:presignedcloudfronturl:cloudfront_pem_found'] = 'Cloudfront private key content (.pem) is valid. OK';
 $string['settings:presignedcloudfronturl:cloudfront_pem_not_found'] = 'Cloudfront private key (.pem) is invalid.';
-$string['settings:sendtotrash'] = 'Send to external storage trashdir';
+$string['settings:relyonorphancleanup'] = 'Delete external file on orphan clean-up';
 $string['settings:fulldelete'] = 'Delete completely';
 
 $string['pleaseselect'] = 'Please, select';

--- a/settings.php
+++ b/settings.php
@@ -87,7 +87,7 @@ if ($ADMIN->fulltree) {
         new lang_string('settings:maxtaskruntime', 'tool_objectfs'), '', HOURSECS, MINSECS));
 
     $options = [TOOL_OBJECTFS_DELETE_EXTERNAL_NO => new lang_string('no'),
-                TOOL_OBJECTFS_DELETE_EXTERNAL_TRASH => new lang_string('settings:sendtotrash', 'tool_objectfs'),
+                TOOL_OBJECTFS_DELETE_EXTERNAL_TRASH => new lang_string('settings:relyonorphancleanup', 'tool_objectfs'),
                 TOOL_OBJECTFS_DELETE_EXTERNAL_FULL => new lang_string('settings:fulldelete', 'tool_objectfs')];
     $settings->add(new admin_setting_configselect('tool_objectfs/deleteexternal',
         new lang_string('settings:deleteexternal', 'tool_objectfs'),

--- a/tests/classes/test_client.php
+++ b/tests/classes/test_client.php
@@ -39,14 +39,6 @@ class test_client extends object_client_base {
         if (!is_dir($this->bucketpath)) {
             mkdir($this->bucketpath);
         }
-        // Trashdir for local storage.
-        if (!is_dir($this->bucketpath . '/trashdir')) {
-            mkdir($this->bucketpath . '/trashdir');
-        }
-        // Trashdir for external storage.
-        if (!is_dir($this->bucketpath . '/trash')) {
-            mkdir($this->bucketpath . '/trash');
-        }
     }
 
     public function get_seekable_stream_context() {
@@ -58,9 +50,6 @@ class test_client extends object_client_base {
         return "$this->bucketpath/{$contenthash}";
     }
 
-    public function get_trash_fullpath_from_hash($contenthash) {
-        return "$this->bucketpath/trashdir/{$contenthash}";
-    }
 
     public function delete_file($fullpath) {
         return unlink($fullpath);
@@ -68,10 +57,6 @@ class test_client extends object_client_base {
 
     public function rename_file($currentpath, $destinationpath) {
         return rename($currentpath, $destinationpath);
-    }
-
-    public function get_external_trash_path_from_hash($contenthash) {
-        return "$this->bucketpath/trash/{$contenthash}";
     }
 
     public function register_stream_wrapper() {

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -462,13 +462,12 @@ class object_file_system_testcase extends tool_objectfs_testcase {
     public function test_object_storage_deleter_can_delete_object_if_enabledelete_is_on_and_object_is_local() {
         global $CFG;
 
-        $CFG->forced_plugin_settings['tool_objectfs']['deleteexternal'] = true;
+        $CFG->forced_plugin_settings['tool_objectfs']['deleteexternal'] = TOOL_OBJECTFS_DELETE_EXTERNAL_FULL;
         $this->filesystem = new test_file_system();
         $file = $this->create_local_file();
         $filehash = $file->get_contenthash();
         $this->delete_draft_files($filehash);
         $this->filesystem->remove_file($filehash);
-        $this->assertTrue($this->is_locally_readable_by_hash_in_trashdir($filehash));
         $this->assertFalse($this->is_locally_readable_by_hash($filehash));
         $this->assertFalse($this->is_externally_readable_by_hash($filehash));
     }
@@ -482,7 +481,6 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $filehash = $file->get_contenthash();
         $this->delete_draft_files($filehash);
         $this->filesystem->remove_file($filehash);
-        $this->assertTrue($this->is_locally_readable_by_hash_in_trashdir($filehash));
         $this->assertFalse($this->is_locally_readable_by_hash($filehash));
         $this->assertFalse($this->is_externally_readable_by_hash($filehash));
     }
@@ -490,7 +488,7 @@ class object_file_system_testcase extends tool_objectfs_testcase {
     public function test_object_storage_deleter_can_delete_object_if_enabledelete_is_on_and_object_is_duplicated() {
         global $CFG;
 
-        $CFG->forced_plugin_settings['tool_objectfs']['deleteexternal'] = true;
+        $CFG->forced_plugin_settings['tool_objectfs']['deleteexternal'] = TOOL_OBJECTFS_DELETE_EXTERNAL_FULL;
         $this->filesystem = new test_file_system();
         $file = $this->create_duplicated_file();
         $filehash = $file->get_contenthash();
@@ -498,7 +496,6 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $this->filesystem->remove_file($filehash);
         $this->assertFalse($this->is_locally_readable_by_hash($filehash));
         $this->assertFalse($this->is_externally_readable_by_hash($filehash));
-        $this->assertTrue($this->is_externally_readable_by_hash_in_trashdir($filehash));
     }
 
     public function test_object_storage_deleter_can_delete_object_if_enabledelete_is_off_and_object_is_duplicated() {
@@ -512,13 +509,12 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $this->filesystem->remove_file($filehash);
         $this->assertFalse($this->is_locally_readable_by_hash($filehash));
         $this->assertTrue($this->is_externally_readable_by_hash($filehash));
-        $this->assertFalse($this->is_externally_readable_by_hash_in_trashdir($filehash));
     }
 
     public function test_object_storage_deleter_can_delete_object_if_enabledelete_is_on_and_object_is_remote() {
         global $CFG;
 
-        $CFG->forced_plugin_settings['tool_objectfs']['deleteexternal'] = true;
+        $CFG->forced_plugin_settings['tool_objectfs']['deleteexternal'] = TOOL_OBJECTFS_DELETE_EXTERNAL_FULL;
         $this->filesystem = new test_file_system();
         $file = $this->create_remote_file();
         $filehash = $file->get_contenthash();
@@ -526,7 +522,6 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $this->filesystem->remove_file($filehash);
         $this->assertFalse($this->is_locally_readable_by_hash($filehash));
         $this->assertFalse($this->is_externally_readable_by_hash($filehash));
-        $this->assertTrue($this->is_externally_readable_by_hash_in_trashdir($filehash));
     }
 
     public function test_object_storage_deleter_can_delete_object_if_enabledelete_is_off_and_object_is_remote() {
@@ -540,7 +535,6 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $this->filesystem->remove_file($filehash);
         $this->assertFalse($this->is_locally_readable_by_hash($filehash));
         $this->assertTrue($this->is_externally_readable_by_hash($filehash));
-        $this->assertFalse($this->is_externally_readable_by_hash_in_trashdir($filehash));
     }
 
     public function test_object_storage_locker_can_acquire_lock_if_object_is_not_locked() {
@@ -553,20 +547,10 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $lock->release();
     }
 
-    public function test_can_recover_object_if_deleted_while_local() {
-        $this->filesystem = new test_file_system();
-        $file = $this->create_local_file();
-        $filehash = $file->get_contenthash();
-        $this->delete_draft_files($filehash);
-        $this->filesystem->remove_file($filehash);
-        $this->recover_file($file);
-        $this->assertTrue($this->is_locally_readable_by_hash($filehash));
-    }
-
     public function test_can_recover_object_if_deleted_while_duplicated() {
         global $CFG;
 
-        $CFG->forced_plugin_settings['tool_objectfs']['deleteexternal'] = true;
+        $CFG->forced_plugin_settings['tool_objectfs']['deleteexternal'] = TOOL_OBJECTFS_DELETE_EXTERNAL_TRASH;
         $this->filesystem = new test_file_system();
         $file = $this->create_duplicated_file();
         $filehash = $file->get_contenthash();
@@ -579,7 +563,7 @@ class object_file_system_testcase extends tool_objectfs_testcase {
     public function test_can_recover_object_if_deleted_while_external() {
         global $CFG;
 
-        $CFG->forced_plugin_settings['tool_objectfs']['deleteexternal'] = true;
+        $CFG->forced_plugin_settings['tool_objectfs']['deleteexternal'] = TOOL_OBJECTFS_DELETE_EXTERNAL_TRASH;
         $this->filesystem = new test_file_system();
         $file = $this->create_remote_file();
         $filehash = $file->get_contenthash();
@@ -587,21 +571,6 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         $this->filesystem->remove_file($filehash);
         $this->recover_file($file);
         $this->assertTrue($this->is_externally_readable_by_hash($filehash));
-    }
-
-    public function test_can_delete_local_file_if_exists_in_trashdir() {
-        $this->filesystem = new test_file_system();
-        $file = $this->create_local_file();
-        $filehash = $file->get_contenthash();
-        $this->delete_draft_files($filehash);
-        $this->filesystem->remove_file($filehash);
-        $this->assertFalse($this->is_locally_readable_by_hash($filehash));
-
-        $file = $this->create_local_file();
-        $filehash = $file->get_contenthash();
-        $this->delete_draft_files($filehash);
-        $this->filesystem->remove_file($filehash);
-        $this->assertFalse($this->is_locally_readable_by_hash($filehash));
     }
 
     public function test_can_generate_signed_url_by_hash_if_object_is_external() {

--- a/tests/tool_objectfs_testcase.php
+++ b/tests/tool_objectfs_testcase.php
@@ -122,12 +122,6 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
         return $reflection->invokeArgs($this->filesystem, [$contenthash]);
     }
 
-    protected function get_external_trash_path_from_hash($contenthash) {
-        $reflection = new \ReflectionMethod(object_file_system::class, 'get_external_trash_path_from_hash');
-        $reflection->setAccessible(true);
-        return $reflection->invokeArgs($this->filesystem, [$contenthash]);
-    }
-
     protected function get_external_path_from_storedfile($file) {
         $contenthash = $file->get_contenthash();
         return $this->get_external_path_from_hash($contenthash);
@@ -136,12 +130,6 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
     // We want acces to local path for testing so we use a reflection method as opposed to rewriting here.
     protected function get_local_path_from_hash($contenthash) {
         $reflection = new \ReflectionMethod(object_file_system::class, 'get_local_path_from_hash');
-        $reflection->setAccessible(true);
-        return $reflection->invokeArgs($this->filesystem, [$contenthash]);
-    }
-
-    protected function get_trash_fullpath_from_hash($contenthash) {
-        $reflection = new \ReflectionMethod(object_file_system::class, 'get_trash_fullpath_from_hash');
         $reflection->setAccessible(true);
         return $reflection->invokeArgs($this->filesystem, [$contenthash]);
     }
@@ -203,16 +191,6 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
         $reflection = new \ReflectionMethod(object_file_system::class, 'acquire_object_lock');
         $reflection->setAccessible(true);
         return $reflection->invokeArgs($this->filesystem, [$filehash, $timeout]);
-    }
-
-    protected function is_locally_readable_by_hash_in_trashdir($contenthash) {
-        $externalpath = $this->get_trash_fullpath_from_hash($contenthash);
-        return is_readable($externalpath);
-    }
-
-    protected function is_externally_readable_by_hash_in_trashdir($contenthash) {
-        $externalpath = $this->get_external_trash_path_from_hash($contenthash);
-        return is_readable($externalpath);
     }
 
     protected function delete_draft_files($contenthash) {


### PR DESCRIPTION
This removes the semi-broken "move to trash location" handling of objectfs and relies on the cleanup task to delete files if set.

One challenge we have with this is that if a site starts with "don't delete" and then moves to "delete using the orphaned file" process is that it won't really delete orphans - only orphans that Moodle still knows about.

Note - this is currently untested live - we should hold off merging until we test this properly, but comments/feedback on the approach prior to then is welcome.