### PR TITLE
Add missing "Principal": "*" in S3 bucket access policy JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,13 @@ There is support for more object stores planed.
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Principal": "*",
       "Effect": "Allow",
       "Action": ["s3:ListBucket"],
       "Resource": ["arn:aws:s3:::bucketname"]
     },
     {
+      "Principal": "*",
       "Effect": "Allow",
       "Action": [
         "s3:PutObject",


### PR DESCRIPTION
It seems AWS updated their S3 bucket access policy settings, which now requires "Principal": "*" in each statement.