### PR TITLE
Added use path endpoint setting for s3

### DIFF
--- a/classes/local/manager.php
+++ b/classes/local/manager.php
@@ -72,6 +72,8 @@ class manager {
         $config->s3_region = 'us-east-1';
         $config->s3_base_url = '';
         $config->key_prefix = '';
+        $config->s3_use_path_style_endpoint = '0';
+
 
         // Digital ocean file system.
         $config->do_key = '';

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -143,6 +143,10 @@ class client extends object_client_base {
             $options['endpoint'] = $config->s3_base_url;
         }
 
+        if ($config->s3_use_path_style_endpoint) {
+            $options['use_path_style_endpoint'] = $config->s3_use_path_style_endpoint;
+        }
+
         $this->client = \Aws\S3\S3Client::factory($options);
     }
 
@@ -425,6 +429,11 @@ class client extends object_client_base {
         $settings->add(new \admin_setting_configtext('tool_objectfs/key_prefix',
             new \lang_string('settings:aws:key_prefix', 'tool_objectfs'),
             new \lang_string('settings:aws:key_prefix_help', 'tool_objectfs'), ''));
+
+        $settings->add(new \admin_setting_configcheckbox('tool_objectfs/s3_use_path_style_endpoint',
+            new \lang_string('settings:aws:usepathstyle', 'tool_objectfs'),
+            new \lang_string('settings:aws:usepathstyle_help', 'tool_objectfs'),
+            '0'));
 
         return $settings;
     }

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -127,6 +127,8 @@ $string['settings:aws:sdkcredsok'] = 'AWS credentials found. This setting can be
 $string['settings:aws:sdkcredserror'] = 'Couldn\'t find AWS credentials. It\'s unsafe to enable this setting. Follow up <a href="https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html">AWS documentation</a>.';
 $string['settings:aws:key_prefix'] = 'Prefix to use in bucket';
 $string['settings:aws:key_prefix_help'] = 'Prefix to use inside Amazon S3 bucket. Must end with trailing slash when set. Leave blank to use root of bucket.';
+$string['settings:aws:usepathstyle'] = 'Use path style endpoint';
+$string['settings:aws:usepathstyle_help'] = 'Check to send requests to an S3 path style endpoint by default. Useful if S3 provider doesn\'t support access to bucket by subdomain.';
 
 $string['settings:do:header'] = 'DigitalOcean Spaces Settings';
 $string['settings:do:key'] = 'Key';


### PR DESCRIPTION
Some S3 type services doesn't support access to bucket by subdomain, this adds a checkbox setting for configuring the s3 client to use the path for accessing the bucket on the endpoint.