### PR TITLE
Revert "S3 pre-signed URL: error with unicode filename #455"

### DIFF
--- a/tests/fixtures/😀.txt
+++ b/tests/fixtures/😀.txt
@@ -1,1 +1,0 @@
-This is a test text file with a unicode character in the file name

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -585,39 +585,6 @@ class object_file_system_testcase extends tool_objectfs_testcase {
         }
     }
 
-    public function test_can_generate_signed_url_with_headers() {
-        $this->filesystem = new test_file_system();
-        $file = $this->create_remote_file();
-        $filehash = $file->get_contenthash();
-        try {
-            $headers = [
-                'Content-Disposition' => 'attachment; filename="filename.txt"',
-                'Content-Type' => 'text/plain',
-            ];
-            $signedurl = $this->filesystem->externalclient->generate_presigned_url($filehash, $headers);
-            $this->assertTrue($this->is_externally_readable_by_url($signedurl));
-        } catch (\coding_exception $e) {
-            $this->assertEquals($e->a, 'Pre-signed URLs not supported');
-        }
-    }
-
-    public function test_can_generate_signed_url_with_unicode_filename() {
-        $this->filesystem = new test_file_system();
-        $file = $this->create_remote_file();
-        $filehash = $file->get_contenthash();
-        try {
-            $headers = [
-                    'Content-Disposition' => 'attachment; filename="😀.txt"',
-                    'Content-Type' => 'text/plain',
-            ];
-            $signedurl = $this->filesystem->externalclient->generate_presigned_url($filehash, $headers);
-            $this->assertTrue($this->is_externally_readable_by_url($signedurl));
-
-        } catch (\coding_exception $e) {
-            $this->assertEquals($e->a, 'Pre-signed URLs not supported');
-        }
-    }
-
     public function test_presigned_url_configured_method_returns_false_if_not_configured() {
         $this->filesystem = new test_file_system();
         $this->assertFalse($this->filesystem->presigned_url_configured());

--- a/tests/tool_objectfs_testcase.php
+++ b/tests/tool_objectfs_testcase.php
@@ -25,7 +25,6 @@ use stored_file;
 use tool_objectfs\local\manager;
 use tool_objectfs\local\object_manipulator\candidates\candidates_finder;
 use tool_objectfs\local\store\object_file_system;
-use tool_objectfs\local\store\signed_url;
 
 require_once(__DIR__ . '/classes/test_client.php');
 require_once(__DIR__ . '/classes/test_file_system.php');
@@ -199,9 +198,9 @@ abstract class tool_objectfs_testcase extends \advanced_testcase {
         $DB->delete_records('files', array('contenthash' => $contenthash));
     }
 
-    protected function is_externally_readable_by_url(signed_url $signedurl) {
+    protected function is_externally_readable_by_url($url) {
         try {
-            $file = fopen($signedurl->url->out(false), 'r');
+            $file = fopen($url, 'r');
             if ($file === false) {
                 $result = false;
             } else {


### PR DESCRIPTION
Reverts catalyst/moodle-tool_objectfs#493

Reopen this PR as the following commit cause 403 error when retrieve files with pre-signed URL

[Set utf-8 encoding in signed URL filename header](https://github.com/catalyst/moodle-tool_objectfs/pull/493/commits/8e107e6f8eac3a92214d2c056493ae6d66ee91b1)