### PR TITLE
Issue505 moodle 310 stable add filesize to objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,3 +6,5 @@ on: [push, pull_request]
 jobs:
   ci:
     uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
+    with:
+      disable_phpdoc: true

--- a/classes/local/object_manipulator/candidates/deleter_candidates.php
+++ b/classes/local/object_manipulator/candidates/deleter_candidates.php
@@ -34,17 +34,12 @@ class deleter_candidates extends manipulator_candidates_base {
      * @return string
      */
     public function get_candidates_sql() {
-        return 'SELECT MAX(f.id),
-                       f.contenthash,
-                       MAX(f.filesize) AS filesize
-                  FROM {files} f
-                  JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
-                 WHERE o.timeduplicated <= :consistancythreshold
-                   AND o.location = :location
-                   AND f.filesize > :sizethreshold
-              GROUP BY f.contenthash,
-                       f.filesize,
-                       o.location';
+        return 'SELECT contenthash,
+                       filesize
+                  FROM {tool_objectfs_objects}
+                 WHERE timeduplicated <= :consistancythreshold
+                   AND location = :location
+                   AND filesize > :sizethreshold';
     }
 
     /**

--- a/classes/local/object_manipulator/candidates/puller_candidates.php
+++ b/classes/local/object_manipulator/candidates/puller_candidates.php
@@ -34,16 +34,11 @@ class puller_candidates extends manipulator_candidates_base {
      * @return string
      */
     public function get_candidates_sql() {
-        return 'SELECT MAX(f.id),
-                       f.contenthash,
-                       MAX(f.filesize) AS filesize
-                  FROM {files} f
-                  JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
-                 WHERE f.filesize <= :sizethreshold
-                   AND o.location = :location
-              GROUP BY f.contenthash,
-                       f.filesize,
-                       o.location';
+        return 'SELECT contenthash,
+                       filesize
+                  FROM {tool_objectfs_objects}
+                 WHERE filesize <= :sizethreshold
+                   AND location = :location';
     }
 
     /**

--- a/classes/local/object_manipulator/candidates/pusher_candidates.php
+++ b/classes/local/object_manipulator/candidates/pusher_candidates.php
@@ -38,16 +38,13 @@ class pusher_candidates extends manipulator_candidates_base {
      * @return string
      */
     public function get_candidates_sql() {
-        return 'SELECT MAX(f.id),
-                       f.contenthash,
-                       MAX(f.filesize) AS filesize
-                  FROM {files} f
-                  JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
-                 WHERE f.filesize > :threshold
-                   AND f.filesize < :maximum_file_size
-                   AND f.timecreated <= :maxcreatedtimestamp
-                   AND o.location = :object_location
-              GROUP BY f.contenthash, o.location';
+        return 'SELECT contenthash,
+                       filesize
+                  FROM {tool_objectfs_objects}
+                 WHERE filesize > :threshold
+                   AND filesize < :maximum_file_size
+                   AND timeduplicated <= :maxcreatedtimestamp
+                   AND location = :object_location';
     }
 
     /**

--- a/classes/local/object_manipulator/candidates/recoverer_candidates.php
+++ b/classes/local/object_manipulator/candidates/recoverer_candidates.php
@@ -34,15 +34,10 @@ class recoverer_candidates extends manipulator_candidates_base {
      * @return string
      */
     public function get_candidates_sql() {
-        return 'SELECT MAX(f.id),
-                       f.contenthash,
-                       MAX(f.filesize) AS filesize
-                  FROM {files} f
-                  JOIN {tool_objectfs_objects} o ON f.contenthash = o.contenthash
-                 WHERE o.location = :location
-              GROUP BY f.contenthash,
-                       f.filesize,
-                       o.location';
+        return 'SELECT contenthash,
+                       filesize
+                  FROM {tool_objectfs_objects}
+                 WHERE location = :location';
     }
 
     /**

--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -865,7 +865,7 @@ abstract class object_file_system extends \file_system_filedir {
         $result = parent::add_file_from_path($pathname, $contenthash);
 
         $location = $this->get_object_location_from_hash($result[0]);
-        manager::update_object_by_hash($result[0], $location);
+        manager::update_object_by_hash($result[0], $location, $result[1]);
 
         return $result;
     }
@@ -880,7 +880,7 @@ abstract class object_file_system extends \file_system_filedir {
         $result = parent::add_file_from_string($content);
 
         $location = $this->get_object_location_from_hash($result[0]);
-        manager::update_object_by_hash($result[0], $location);
+        manager::update_object_by_hash($result[0], $location, $result[1]);
 
         return $result;
     }

--- a/classes/task/populate_objects_filesize.php
+++ b/classes/task/populate_objects_filesize.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\task;
+
+use core\task\adhoc_task;
+use core\task\manager;
+
+/**
+ * Ad-hoc task to update objects table. Used for async upgrade.
+ *
+ * @package    tool_objectfs
+ * @author     Andrew Madden <andrewmadden@catalyst-au.net>
+ * @copyright  2022 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class populate_objects_filesize extends adhoc_task {
+
+    /** @var int Max number of updates that task should trigger before scheduling a new task. */
+    private const MAX_UPDATES = 100000;
+
+    /**
+     * Action of task.
+     */
+    public function execute() {
+        global $DB;
+
+        // Get the custom data.
+        $data = $this->get_custom_data();
+        $maxupdates = !empty($data->maxupdates) ? $data->maxupdates : self::MAX_UPDATES;
+
+        // Get all objects without a filesize and join them to a filesize from the files table.
+        $sql = "SELECT o.id, o.contenthash, o.timeduplicated, o.location, f.filesize
+                  FROM {tool_objectfs_objects} o
+             LEFT JOIN {files} f ON o.contenthash = f.contenthash
+                 WHERE o.filesize IS NULL
+              GROUP BY o.id,
+                       o.contenthash,
+                       f.filesize";
+        $records = $DB->get_recordset_sql($sql);
+
+        // If more records found than the max number of updates, only process max updates then queue new task.
+        $queueadditionaltask = false;
+
+        $updatecount = 0;
+        foreach ($records as $record) {
+            if ($updatecount >= $maxupdates) {
+                $queueadditionaltask = true;
+                break;
+            }
+            $DB->update_record('tool_objectfs_objects', $record, true);
+            $updatecount += 1;
+        }
+        $records->close();
+
+        if ($queueadditionaltask) {
+            manager::queue_adhoc_task(new populate_objects_filesize());
+        }
+    }
+}

--- a/db/install.xml
+++ b/db/install.xml
@@ -10,6 +10,7 @@
         <FIELD NAME="contenthash" TYPE="char" LENGTH="40" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="timeduplicated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="location" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="filesize" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="contenthash" TYPE="unique" FIELDS="contenthash"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -136,5 +136,23 @@ function xmldb_tool_objectfs_upgrade($oldversion) {
 
         upgrade_plugin_savepoint(true, 2021090100, 'tool', 'objectfs');
     }
+
+    if ($oldversion < 2022070401) {
+
+        // Add filesize field to objects table.
+        $table = new xmldb_table('tool_objectfs_objects');
+        $field = new xmldb_field('filesize', XMLDB_TYPE_INTEGER, '20');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        } else {
+            $dbman->drop_field($table, $field);
+            $dbman->add_field($table, $field);
+        }
+
+        // Populate the filesize field.
+        \core\task\manager::queue_adhoc_task(new \tool_objectfs\task\populate_objects_filesize());
+
+        upgrade_plugin_savepoint(true, 2022070401, 'tool', 'objectfs');
+    }
     return true;
 }

--- a/tests/task/populate_objects_filesize_test.php
+++ b/tests/task/populate_objects_filesize_test.php
@@ -1,0 +1,206 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\task;
+
+use tool_objectfs\tests\tool_objectfs_testcase;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once("$CFG->dirroot/admin/tool/objectfs/tests/tool_objectfs_testcase.php");
+
+/**
+ * Test adhoc-task populate_objects_filesize.
+ *
+ * @package    tool_objectfs
+ * @author     Andrew Madden <andrewmadden@catalyst-au.net>
+ * @copyright  2022 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \tool_objectfs\task\populate_objects_filesize
+ */
+class populate_objects_filesize_test extends tool_objectfs_testcase {
+
+    /**
+     * This method runs before every test.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Test multiple objects have their filesize updated.
+     */
+    public function test_empty_filesizes_updated() {
+        global $DB;
+        $this->create_local_file("Test 1");
+        $this->create_local_file("Test 2");
+        $this->create_local_file("Test 3");
+        $this->create_local_file("Test 4");
+        $this->create_local_file("This is a looong name");
+
+        // Set all objects to have a filesize of null.
+        $DB->set_field('tool_objectfs_objects', 'filesize', null);
+
+        // Call ad-hoc task to populate filesizes.
+        $task = new \tool_objectfs\task\populate_objects_filesize();
+        $task->execute();
+
+        // Get all objects.
+        $objects = $DB->get_records('tool_objectfs_objects');
+
+        // Test all object records have populated file sizes.
+        $this->assertCount(5, $objects);
+        foreach ($objects as $object) {
+            $this->assertNotEmpty($object->filesize);
+        }
+    }
+
+    /**
+     * Test filesize is not updated from 0, if file is empty.
+     */
+    public function test_empty_filesizes_with_real_empty_files_not_updated() {
+        global $DB;
+        $this->create_local_file("");
+
+        // Set all objects to have a filesize of null.
+        $DB->set_field('tool_objectfs_objects', 'filesize', null);
+
+        // Call ad-hoc task to populate filesizes.
+        $task = new \tool_objectfs\task\populate_objects_filesize();
+        $task->execute();
+
+        // Get all objects.
+        $objects = $DB->get_records('tool_objectfs_objects');
+
+        // Test object record has empty file size.
+        $this->assertCount(1, $objects);
+        foreach ($objects as $object) {
+            $this->assertEmpty($object->filesize);
+        }
+    }
+
+    /**
+     * Test that file size is updated accurately.
+     */
+    public function test_filesize_updated_accurately() {
+        global $DB;
+        $file1 = $this->create_local_file("four");
+        $file2 = $this->create_local_file("five5");
+
+        // Set all objects to have a filesize of null.
+        $DB->set_field('tool_objectfs_objects', 'filesize', null);
+
+        // Call ad-hoc task to populate filesizes.
+        $task = new \tool_objectfs\task\populate_objects_filesize();
+        $task->execute();
+
+        // Get all objects.
+        $objects = $DB->get_records('tool_objectfs_objects');
+
+        // Test all object records have populated file sizes.
+        $this->assertCount(2, $objects);
+        foreach ($objects as $object) {
+            if ($object->contenthash == $file1->get_contenthash()) {
+                $this->assertEquals(4, $object->filesize);
+            } else if ($object->contenthash == $file2->get_contenthash()) {
+                $this->assertEquals(5, $object->filesize);
+            }
+        }
+    }
+
+    /**
+     * Test that the maxupdates value limits the number of records updated and new adhoc task is scheduled.
+     */
+    public function test_only_max_update_records_are_updated() {
+        global $DB;
+        $this->create_local_file("Test 1");
+        $this->create_local_file("Test 2");
+        $this->create_local_file("Test 3");
+        $this->create_local_file("Test 4");
+        $this->create_local_file("This is a looong name");
+
+        // Set all objects to have a filesize of null.
+        $DB->set_field('tool_objectfs_objects', 'filesize', null);
+
+        // Call ad-hoc task to populate filesizes.
+        $task = new \tool_objectfs\task\populate_objects_filesize();
+        $task->set_custom_data(['maxupdates' => 2]);
+        $task->execute();
+
+        // Get all objects.
+        $objects = $DB->get_records('tool_objectfs_objects');
+        $updatedobjects = array_filter($objects, function($object) {
+            return isset($object->filesize);
+        });
+
+        // Test only 2 records have updated filesize.
+        $this->assertCount(5, $objects);
+        $this->assertCount(2, $updatedobjects);
+
+        // Test new adhoc task was scheduled.
+        if (!method_exists(\core\task\manager::class, 'get_adhoc_tasks')) {
+            $this->markTestSkipped('\core\task\manager::get_adhoc_tasks() not available before Moodle 3.4');
+        }
+        $adhoctasks = \core\task\manager::get_adhoc_tasks(populate_objects_filesize::class);
+        $this->assertCount(1, $adhoctasks);
+    }
+
+    /**
+     * Test that filesizes that are already populated are not pulled again.
+     */
+    public function test_that_non_null_values_are_not_updated() {
+        global $DB;
+        $this->create_local_file("Test 1");
+        $this->create_local_file("Test 2");
+        $this->create_local_file("Test 3");
+        $this->create_local_file("Test 4");
+        $this->create_local_file("This is a looong name");
+
+        // Set all objects to have a filesize of null.
+        $DB->set_field('tool_objectfs_objects', 'filesize', null);
+
+        // Call ad-hoc task to populate filesizes.
+        $task = new \tool_objectfs\task\populate_objects_filesize();
+        $task->set_custom_data(['maxupdates' => 2]);
+        $task->execute();
+
+        // Get all objects.
+        $objects = $DB->get_records('tool_objectfs_objects');
+        $updatedobjects = array_filter($objects, function($object) {
+            return isset($object->filesize);
+        });
+
+        // Test only 2 records have updated filesize.
+        $this->assertCount(5, $objects);
+        $this->assertCount(2, $updatedobjects);
+
+        // Call ad-hoc task to populate filesizes.
+        $task = new \tool_objectfs\task\populate_objects_filesize();
+        $task->set_custom_data(['maxupdates' => 2]);
+        $task->execute();
+
+        // Get all objects.
+        $objects = $DB->get_records('tool_objectfs_objects');
+        $updatedobjects = array_filter($objects, function($object) {
+            return isset($object->filesize);
+        });
+
+        // Test that 4 records have now been updated.
+        $this->assertCount(5, $objects);
+        $this->assertCount(4, $updatedobjects);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022070400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2022070400;      // Same as version.
+$plugin->version   = 2022070401;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2022070401;      // Same as version.
 $plugin->requires  = 2020110900;      // Requires Filesystem API.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
* Add filesize to objects table
* Create adhoc task that can populate filesize automatically
* Call adhoc in upgrade
* Update SQL queries that no longer need to join files table
* Initiate filesize when creating an object