### PR TITLE
Fixing lock release error

### DIFF
--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -214,6 +214,7 @@ abstract class object_file_system extends \file_system_filedir {
         $lockfactory = \core\lock\lock_config::get_lock_factory('tool_objectfs_object');
         $this->logger->start_timing();
         $lock = $lockfactory->get_lock($resource, $timeout);
+        $lock->release();
         $this->logger->end_timing();
         $this->logger->log_lock_timing($lock);
 


### PR DESCRIPTION
In Moodle 3.11.+ we getting this error: 

`A lock was created but not released at: [dirroot]/admin/tool/objectfs/classes/local/store/object_file_system.php on line 216 Code should look like: $factory = \core\lock\lock_config::get_lock_factory('type'); $lock = $factory->get_lock(50e571f912ea1e8d29ccfeb56a43748b59f24c3d); $lock->release(); // Locks must ALWAYS be released like this.`

In my scenario, looks it´s happening when I try access objectfs in interface and cron in same time.