### PR TITLE
Fix-547: Eliminated legacy cron error.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -69,22 +69,6 @@ define('TOOL_OBJECTFS_DELETE_EXTERNAL_NO', 0);
 define('TOOL_OBJECTFS_DELETE_EXTERNAL_TRASH', 1);
 define('TOOL_OBJECTFS_DELETE_EXTERNAL_FULL', 2);
 
-// Legacy cron function.
-function tool_objectfs_cron() {
-    mtrace('RUNNING legacy cron objectfs');
-    global $CFG;
-    if ($CFG->branch <= 26) {
-        // Unlike the task system, we do not get fine grained control over
-        // when tasks/manipulators run. Every cron we just run all the manipulators.
-        (new manipulator_builder())->execute_all();
-
-        \tool_objectfs\local\report\objectfs_report::cleanup_reports();
-        \tool_objectfs\local\report\objectfs_report::generate_status_report();
-    }
-
-    return true;
-}
-
 /**
  * Sends a plugin file to the browser.
  * @param $course

--- a/tests/local/tasks_test.php
+++ b/tests/local/tasks_test.php
@@ -32,13 +32,6 @@ class tasks_test extends \tool_objectfs\tests\testcase {
         ob_end_clean();
     }
 
-    public function test_run_legacy_cron() {
-        $config = manager::get_objectfs_config();
-        $config->enabletasks = true;
-        manager::set_objectfs_config($config);
-        $this->assertTrue(tool_objectfs_cron());
-    }
-
     public function test_run_scheduled_tasks() {
         global $CFG;
         // If tasks not implemented.


### PR DESCRIPTION
This is to address the issue described in:
https://github.com/catalyst/moodle-tool_objectfs/issues/547