### PR TITLE
Improve populate_objects_filesize performance by limiting db results

### DIFF
--- a/classes/task/populate_objects_filesize.php
+++ b/classes/task/populate_objects_filesize.php
@@ -52,7 +52,7 @@ class populate_objects_filesize extends adhoc_task {
               GROUP BY o.id,
                        o.contenthash,
                        f.filesize";
-        $records = $DB->get_recordset_sql($sql);
+        $records = $DB->get_recordset_sql($sql, null, 0, $maxupdates + 1);
 
         // If more records found than the max number of updates, only process max updates then queue new task.
         $queueadditionaltask = false;


### PR DESCRIPTION
I have been investigating an issue with populate_objects_filesize task - you already fixed the main issue (that it never finishes) by correcting the join, however as well as not finishing, we noticed it seemed to use a large amount of database storage, with associated costs. 

Partially this might just be because it's a big query, but some of it might be related to the fact that it queries the entire results, then uses only the first $maxresults of them. Although this is a recordset I suspect it will still read more than it needs, so I added in a liimit.

I have applied this change to our local copy and it appears to still work, i.e. on our test server everything that should have a filesize now does. To be honest from our point of view we don't mind if you put this change in because we will have finished running the task before we next update from your codebase, but I thought I would submit just in case it's useful to others.