### PR TITLE
replaced deprecated function cron_trace_time_and_memory() for Moodle 4.2+

### DIFF
--- a/classes/task/delete_local_empty_directories.php
+++ b/classes/task/delete_local_empty_directories.php
@@ -27,10 +27,9 @@ namespace tool_objectfs\task;
 
 use coding_exception;
 use tool_objectfs\local\manager;
+use core\cron;
 
 defined('MOODLE_INTERNAL') || die();
-
-require_once($CFG->libdir.'/cronlib.php');
 
 class delete_local_empty_directories  extends task {
 
@@ -51,7 +50,7 @@ class delete_local_empty_directories  extends task {
             return;
         }
         $filesystem = new $this->config->filesystem();
-        cron_trace_time_and_memory();
+        cron::trace_time_and_memory();
         $filesystem->delete_empty_dirs();
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -69,22 +69,6 @@ define('TOOL_OBJECTFS_DELETE_EXTERNAL_NO', 0);
 define('TOOL_OBJECTFS_DELETE_EXTERNAL_TRASH', 1);
 define('TOOL_OBJECTFS_DELETE_EXTERNAL_FULL', 2);
 
-// Legacy cron function.
-function tool_objectfs_cron() {
-    mtrace('RUNNING legacy cron objectfs');
-    global $CFG;
-    if ($CFG->branch <= 26) {
-        // Unlike the task system, we do not get fine grained control over
-        // when tasks/manipulators run. Every cron we just run all the manipulators.
-        (new manipulator_builder())->execute_all();
-
-        \tool_objectfs\local\report\objectfs_report::cleanup_reports();
-        \tool_objectfs\local\report\objectfs_report::generate_status_report();
-    }
-
-    return true;
-}
-
 /**
  * Sends a plugin file to the browser.
  * @param $course

--- a/tests/local/tasks_test.php
+++ b/tests/local/tasks_test.php
@@ -32,13 +32,6 @@ class tasks_test extends \tool_objectfs\tests\testcase {
         ob_end_clean();
     }
 
-    public function test_run_legacy_cron() {
-        $config = manager::get_objectfs_config();
-        $config->enabletasks = true;
-        manager::set_objectfs_config($config);
-        $this->assertTrue(tool_objectfs_cron());
-    }
-
     public function test_run_scheduled_tasks() {
         global $CFG;
         // If tasks not implemented.


### PR DESCRIPTION
As this change is required for Moodle 4.2+ only I suggest to create a new branch (e.g. MOODLE_402_STABLE)