### PR TITLE
Removed legacy cron function

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -69,22 +69,6 @@ define('TOOL_OBJECTFS_DELETE_EXTERNAL_NO', 0);
 define('TOOL_OBJECTFS_DELETE_EXTERNAL_TRASH', 1);
 define('TOOL_OBJECTFS_DELETE_EXTERNAL_FULL', 2);
 
-// Legacy cron function.
-function tool_objectfs_cron() {
-    mtrace('RUNNING legacy cron objectfs');
-    global $CFG;
-    if ($CFG->branch <= 26) {
-        // Unlike the task system, we do not get fine grained control over
-        // when tasks/manipulators run. Every cron we just run all the manipulators.
-        (new manipulator_builder())->execute_all();
-
-        \tool_objectfs\local\report\objectfs_report::cleanup_reports();
-        \tool_objectfs\local\report\objectfs_report::generate_status_report();
-    }
-
-    return true;
-}
-
 /**
  * Sends a plugin file to the browser.
  * @param $course

--- a/tests/local/tasks_test.php
+++ b/tests/local/tasks_test.php
@@ -32,13 +32,6 @@ class tasks_test extends \tool_objectfs\tests\testcase {
         ob_end_clean();
     }
 
-    public function test_run_legacy_cron() {
-        $config = manager::get_objectfs_config();
-        $config->enabletasks = true;
-        manager::set_objectfs_config($config);
-        $this->assertTrue(tool_objectfs_cron());
-    }
-
     public function test_run_scheduled_tasks() {
         global $CFG;
         // If tasks not implemented.


### PR DESCRIPTION
In Moodle 4.2, cron_trace_time_and_memory has been replaced by a different function in a namespaced location, and you get deprecation warnings for including cronlib.php as well as for calling the function.

This change removes the old cron function in lib.php, and changes the code that calls cron_trace_time_and_memory so that it uses the old method prior to 4.2, and the new one after.

Note: This is a duplicate of #568 but I wrote the code before I saw that one! While it is safe in the MOODLE_310_STABLE branch, to remove the cron function from lib.php (as 3.10 already supported task API), it is not safe to change the cron_trace_time_and_memory function because the new \core\cron class does not exist in 3.10, or any version until 4.2. So I added a version check. 