### PR TITLE
Remove custom printer from phpunit config

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,7 +13,6 @@
         stopOnFailure="false"
         stopOnIncomplete="false"
         stopOnSkipped="false"
-        printerClass="Hint_ResultPrinter"
         >
 
     <php>


### PR DESCRIPTION
See MDL-67673 and Moodle commit cc1c4de for details. Custom printer no longer works in 3.10+, it was deprecated