### PR TITLE
Fix unit tests in Moodle 4.2 and extend CI up to Moodle 4.2

### DIFF
--- a/classes/task/delete_local_empty_directories.php
+++ b/classes/task/delete_local_empty_directories.php
@@ -30,8 +30,6 @@ use tool_objectfs\local\manager;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir.'/cronlib.php');
-
 class delete_local_empty_directories  extends task {
 
     /** @var string $stringname  */
@@ -51,7 +49,6 @@ class delete_local_empty_directories  extends task {
             return;
         }
         $filesystem = new $this->config->filesystem();
-        cron_trace_time_and_memory();
         $filesystem->delete_empty_dirs();
     }
 }

--- a/version.php
+++ b/version.php
@@ -30,4 +30,4 @@ $plugin->release   = 2023051701;      // Same as version.
 $plugin->requires  = 2020110900;      // Requires Filesystem API.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->supported = [310, 401];
+$plugin->supported = [310, 402];


### PR DESCRIPTION
This resolves #584 

It looks like `cron_trace_time_and_memory();` is not needed. All scheduled tasks have this invoked by default, eg https://github.com/moodle/moodle/blob/master/lib/classes/cron.php#L389

Also no other objectfs tasks had this method called so it should be fine to remove it without replacing new \core\cron class which would require a new moodle 4.2 stable branch.