### PR TITLE
Remove use of utf8_encode (deprecated in PHP 8.2)

### DIFF
--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -604,7 +604,13 @@ class client extends object_client_base {
 
             if (!empty($originalfilename)) {
                 $result['Content-Disposition'] = $contentdisposition;
-                $result['filename'] = 'filename="' . utf8_encode($originalfilename) . '"';
+                // The filename parameter must be in ISO-8859-1, however it works in browsers if
+                // you treat the original UTF-8 string as ISO-8859-1 characters. To achieve that
+                // here, we encode the UTF-8 as if it were ISO-8859-1. This behaviour is hideous
+                // so it would be nice to use the optional filename* field (RFC 5987) but S3 still
+                // complains if we do that.
+                $jankyfilename = \core_text::convert($originalfilename, 'ISO-8859-1');
+                $result['filename'] = 'filename="' . $jankyfilename . '"';
                 $result['Content-Type'] = $originalcontenttype;
             }
         }


### PR DESCRIPTION
To go with my other PHP 8.2 fix PR #586...

There is a use of deprecated function utf8_encode. But, the way it's used appears to be entirely pointless - it is calling utf8_encode to create a header based on a string that already came from a header which should already be in UTF-8 (or possibly ISO-8859-1, but anyway).

@marxjohnson already pointed out this was unnecessary in #455

There do seem to be some problems related to S3 and character encoding re. Content-Disposition but I find it hard to believe that calling utf8_encode would help - in fact it sounds like UTF8 isn't technically allowed there and the right answer seems to be something very complicated with URL-encoding and a filename* parmeter as well a filename, according to this blog https://engineering.resolvergroup.com/2022/02/aws-s3-utf-8-content-disposition/

