### PR TITLE
Issue #609: When a file size is 0 bytes do not mark it as location error

### DIFF
--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -406,7 +406,7 @@ abstract class object_file_system extends \file_system_filedir {
 
             $this->logger->log_object_read('readfile', $path, $file->get_filesize());
 
-            if (!$success) {
+            if ($success === false) {
                 manager::update_object_by_hash($file->get_contenthash(), OBJECT_LOCATION_ERROR);
             }
         }

--- a/classes/local/store/s3/file_system.php
+++ b/classes/local/store/s3/file_system.php
@@ -59,7 +59,7 @@ class file_system extends object_file_system {
         $this->get_logger()->end_timing();
         $this->get_logger()->log_object_read('readfile', $path, $file->get_filesize());
 
-        if (!$success) {
+        if ($success === false) {
             manager::update_object_by_hash($file->get_contenthash(), OBJECT_LOCATION_ERROR);
             throw new \file_exception('storedfilecannotreadfile', $file->get_filename());
         }


### PR DESCRIPTION
Hi all,

I have created this PR to fix issue #609.

When the file has a size of 0, `readfile_allow_large` and `readfile` will return 0. The code mistakenly treats it as false when validating if it succeeded or not.

Regards,
Guillermo