### PR TITLE
Fix code standards and deprecations

### DIFF
--- a/classes/local/object_manipulator/candidates/deleter_candidates.php
+++ b/classes/local/object_manipulator/candidates/deleter_candidates.php
@@ -57,7 +57,7 @@ class deleter_candidates extends manipulator_candidates_base {
         return [
             'consistancythreshold' => $consistancythreshold,
             'location' => OBJECT_LOCATION_DUPLICATED,
-            'sizethreshold' => $this->config->sizethreshold
+            'sizethreshold' => $this->config->sizethreshold,
         ];
     }
 }

--- a/classes/local/object_manipulator/candidates/orphaner_candidates.php
+++ b/classes/local/object_manipulator/candidates/orphaner_candidates.php
@@ -53,7 +53,7 @@ class orphaner_candidates extends manipulator_candidates_base {
      */
     public function get_candidates_sql_params() {
         return [
-          'location' => OBJECT_LOCATION_ORPHANED
+          'location' => OBJECT_LOCATION_ORPHANED,
         ];
     }
 }

--- a/classes/local/object_manipulator/manipulator_builder.php
+++ b/classes/local/object_manipulator/manipulator_builder.php
@@ -48,7 +48,7 @@ class manipulator_builder {
         pusher::class,
         recoverer::class,
         checker::class,
-        orphaner::class
+        orphaner::class,
     ];
 
     /** @var string $manipulatorclass */

--- a/classes/local/report/location_report_builder.php
+++ b/classes/local/report/location_report_builder.php
@@ -47,7 +47,7 @@ class location_report_builder extends objectfs_report_builder {
             OBJECT_LOCATION_DUPLICATED,
             OBJECT_LOCATION_EXTERNAL,
             OBJECT_LOCATION_ORPHANED,
-            OBJECT_LOCATION_ERROR
+            OBJECT_LOCATION_ERROR,
         ];
 
         $totalcount = 0;
@@ -71,7 +71,7 @@ class location_report_builder extends objectfs_report_builder {
 
             if ($location !== OBJECT_LOCATION_ORPHANED) {
                 // Process the query normally.
-                $result = $DB->get_record_sql($sql, array($location));
+                $result = $DB->get_record_sql($sql, [$location]);
             } else if ($location === OBJECT_LOCATION_ORPHANED) {
                 // Start the query from objectfs, for ORPHANED objects, they are not located in the files table.
                 $sql = 'SELECT COALESCE(count(sub.contenthash) ,0) AS objectcount
@@ -80,7 +80,7 @@ class location_report_builder extends objectfs_report_builder {
                                   LEFT JOIN {files} f on f.contenthash = o.contenthash
                                   GROUP BY o.contenthash, f.filesize, o.location
                                   HAVING o.location = ?' . $localsql .') AS sub';
-                $result = $DB->get_record_sql($sql, array($location));
+                $result = $DB->get_record_sql($sql, [$location]);
                 $result->objectsum = 0;
             }
 

--- a/classes/local/report/object_location_history_table.php
+++ b/classes/local/report/object_location_history_table.php
@@ -82,7 +82,7 @@ class object_location_history_table extends \table_sql {
     public function query_db($pagesize, $useinitialsbar = true) {
         global $DB;
         $fields = 'CONCAT(reportid, datakey) AS uid, datakey AS location, objectcount AS count, objectsum AS size';
-        $conditions = array('reporttype' => 'location');
+        $conditions = ['reporttype' => 'location'];
         $rawrecords = $DB->get_records('tool_objectfs_report_data', $conditions, 'reportid', $fields);
         $reports = objectfs_report::get_report_ids();
 
@@ -90,7 +90,7 @@ class object_location_history_table extends \table_sql {
         // NOTE: This avoids the need to null coalesce on a non-existing count/size.
         $emptyrecord = (object)[
             'count' => 0,
-            'size' => 0
+            'size' => 0,
         ];
         foreach ($reports as $id => $timecreated) {
             // Initialises the records to be used, and fallback to an empty one if not found.

--- a/classes/local/report/object_status_history_table.php
+++ b/classes/local/report/object_status_history_table.php
@@ -102,7 +102,7 @@ class object_status_history_table extends \table_sql {
             default:
                 $sort = 'heading ASC';
         }
-        $params = array('reporttype' => $this->reporttype, 'reportid' => $this->reportid);
+        $params = ['reporttype' => $this->reporttype, 'reportid' => $this->reportid];
         $fields = 'datakey AS heading, objectcount AS count, objectsum AS size';
         $rows = $DB->get_records('tool_objectfs_report_data', $params, $sort, $fields);
         $this->rawdata = $rows;
@@ -196,7 +196,7 @@ class object_status_history_table extends \table_sql {
         if ($max > 0) {
             $share = round(100 * $value / $max, $precision);
         }
-        $htmlparams = array('class' => 'ofs-bar', 'style' => 'width:'.$share.'%');
+        $htmlparams = ['class' => 'ofs-bar', 'style' => 'width:'.$share.'%'];
 
         switch ($type) {
             case 'count':

--- a/classes/local/report/objectfs_report.php
+++ b/classes/local/report/objectfs_report.php
@@ -150,7 +150,7 @@ class objectfs_report implements \renderable {
     public static function cleanup_reports() {
         global $DB;
         $reportdate = time() - YEARSECS;
-        $params = array('reportdate' => $reportdate);
+        $params = ['reportdate' => $reportdate];
         $reports = $DB->get_records_select('tool_objectfs_reports', 'reportdate < :reportdate', $params, 'id', 'id');
         $reportids = array_keys($reports);
         $DB->delete_records_list('tool_objectfs_reports', 'id', $reportids);
@@ -177,7 +177,7 @@ class objectfs_report implements \renderable {
      */
     public static function get_report_ids() {
         global $DB;
-        $reports = array();
+        $reports = [];
         $records = $DB->get_records('tool_objectfs_reports', null, 'id DESC', 'id, reportdate');
         foreach ($records as $record) {
             $reports[$record->id] = $record->reportdate;

--- a/classes/local/store/azure/client.php
+++ b/classes/local/store/azure/client.php
@@ -149,11 +149,11 @@ class client extends object_client_base {
      * @return resource
      */
     public function get_seekable_stream_context() {
-        $context = stream_context_create(array(
-            'blob' => array(
-                'seekable' => true
-            )
-        ));
+        $context = stream_context_create([
+            'blob' => [
+                'seekable' => true,
+            ],
+        ]);
         return $context;
     }
 
@@ -259,7 +259,7 @@ class client extends object_client_base {
     public function test_permissions($testdelete) {
         $permissions = new \stdClass();
         $permissions->success = true;
-        $permissions->messages = array();
+        $permissions->messages = [];
 
         try {
             $result = $this->client->createBlockBlob($this->container, 'permissions_check_file', 'permissions_check_file');

--- a/classes/local/store/digitalocean/client.php
+++ b/classes/local/store/digitalocean/client.php
@@ -77,12 +77,12 @@ class client extends s3_client {
             return;
         }
 
-        $this->client = \Aws\S3\S3Client::factory(array(
-            'credentials' => array('key' => $config->do_key, 'secret' => $config->do_secret),
+        $this->client = \Aws\S3\S3Client::factory([
+            'credentials' => ['key' => $config->do_key, 'secret' => $config->do_secret],
             'region' => $config->do_region,
             'endpoint' => 'https://' . $config->do_region . '.digitaloceanspaces.com',
-            'version' => AWS_API_VERSION
-        ));
+            'version' => AWS_API_VERSION,
+        ]);
     }
 
     /**
@@ -93,13 +93,13 @@ class client extends s3_client {
      */
     public function define_client_section($settings, $config) {
 
-        $regionoptions = array(
+        $regionoptions = [
             'sfo2'      => 'sfo2 (San Fransisco)',
             'nyc3'      => 'nyc3 (New York City)',
             'ams3'      => 'ams3 (Amsterdam)',
             'sgp1'      => 'spg1 (Singapore)',
             'fra1'      => 'fra1 (Frankfurt)',
-        );
+        ];
 
         $settings->add(new \admin_setting_heading('tool_objectfs/do',
             new \lang_string('settings:do:header', 'tool_objectfs'), ''));

--- a/classes/local/store/object_client.php
+++ b/classes/local/store/object_client.php
@@ -98,7 +98,7 @@ interface object_client {
      *
      * @return mixed
      */
-    public function generate_presigned_url($contenthash, $headers = array());
+    public function generate_presigned_url($contenthash, $headers = []);
 
     /**
      * support_presigned_urls

--- a/classes/local/store/object_client_base.php
+++ b/classes/local/store/object_client_base.php
@@ -103,7 +103,7 @@ abstract class object_client_base implements object_client {
      *
      * @throws \coding_exception
      */
-    public function generate_presigned_url($contenthash, $headers = array()) {
+    public function generate_presigned_url($contenthash, $headers = []) {
         throw new \coding_exception("Pre-signed URLs not supported");
     }
 

--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -470,7 +470,7 @@ abstract class object_file_system extends \file_system_filedir {
                             $pathinfo['filename'],
                             $pathinfo['basename'],
                             $pathinfo['filename'],
-                            $pathinfo['basename']
+                            $pathinfo['basename'],
                         ]);
 
                         if (!$exists) {
@@ -844,7 +844,7 @@ abstract class object_file_system extends \file_system_filedir {
      * @return bool
      * @throws \dml_exception
      */
-    public function redirect_to_presigned_url($contenthash, $headers = array()) {
+    public function redirect_to_presigned_url($contenthash, $headers = []) {
         global $FULLME;
         try {
             $signedurl = $this->externalclient->generate_presigned_url($contenthash, $headers);
@@ -926,7 +926,7 @@ abstract class object_file_system extends \file_system_filedir {
      * @return bool
      * @throws \dml_exception
      */
-    public function presigned_url_should_redirect($contenthash, $headers = array()) {
+    public function presigned_url_should_redirect($contenthash, $headers = []) {
         // Redirect regardless.
         if ($this->externalclient->presignedminfilesize == 0 &&
                 manager::all_extensions_whitelisted()) {

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -91,7 +91,7 @@ class client extends object_client_base {
      * @return array
      */
     public function __sleep() {
-        return array('bucket');
+        return ['bucket'];
     }
 
     /**
@@ -150,17 +150,17 @@ class client extends object_client_base {
             return;
         }
 
-        $options = array(
+        $options = [
             'region' => $config->s3_region,
-            'version' => AWS_API_VERSION
-        );
+            'version' => AWS_API_VERSION,
+        ];
 
         if (empty($config->s3_usesdkcreds)) {
-            $options['credentials'] = array('key' => $config->s3_key, 'secret' => $config->s3_secret);
+            $options['credentials'] = ['key' => $config->s3_key, 'secret' => $config->s3_secret];
         }
 
         if ($config->useproxy) {
-            $options['http'] = array('proxy' => $this->get_proxy_string());
+            $options['http'] = ['proxy' => $this->get_proxy_string()];
         }
 
         // Support base_url config for aws api compatible endpoints.
@@ -196,9 +196,9 @@ class client extends object_client_base {
 
         try {
             $key = $this->get_filepath_from_hash($contenthash);
-            $result = $this->client->headObject(array(
+            $result = $this->client->headObject([
                             'Bucket' => $this->bucket,
-                            'Key' => $this->bucketkeyprefix . $key));
+                            'Key' => $this->bucketkeyprefix . $key]);
         } catch (\Aws\S3\Exception\S3Exception $e) {
             return false;
         }
@@ -265,11 +265,11 @@ class client extends object_client_base {
      * @return mixed
      */
     public function get_seekable_stream_context() {
-        $context = stream_context_create(array(
-            's3' => array(
-                'seekable' => true
-            )
-        ));
+        $context = stream_context_create([
+            's3' => [
+                'seekable' => true,
+            ],
+        ]);
         return $context;
     }
 
@@ -303,7 +303,7 @@ class client extends object_client_base {
                 $connection->success = false;
                 $connection->details = get_string('settings:notconfigured', 'tool_objectfs');
             } else {
-                $this->client->headBucket(array('Bucket' => $this->bucket));
+                $this->client->headBucket(['Bucket' => $this->bucket]);
             }
         } catch (\Aws\S3\Exception\S3Exception $e) {
             $connection->success = false;
@@ -331,19 +331,19 @@ class client extends object_client_base {
     public function test_permissions($testdelete) {
         $permissions = new \stdClass();
         $permissions->success = true;
-        $permissions->messages = array();
+        $permissions->messages = [];
 
         if ($this->is_functional()) {
             $permissions->success = false;
-            $permissions->messages = array();
+            $permissions->messages = [];
             return $permissions;
         }
 
         try {
-            $result = $this->client->putObject(array(
+            $result = $this->client->putObject([
                 'Bucket' => $this->bucket,
                 'Key' => $this->bucketkeyprefix . 'permissions_check_file',
-                'Body' => 'test content'));
+                'Body' => 'test content']);
         } catch (\Aws\S3\Exception\S3Exception $e) {
             $details = $this->get_exception_details($e);
             $permissions->messages[get_string('settings:writefailure', 'tool_objectfs') . $details] = 'notifyproblem';
@@ -351,9 +351,9 @@ class client extends object_client_base {
         }
 
         try {
-            $result = $this->client->getObject(array(
+            $result = $this->client->getObject([
                 'Bucket' => $this->bucket,
-                'Key' => $this->bucketkeyprefix . 'permissions_check_file'));
+                'Key' => $this->bucketkeyprefix . 'permissions_check_file']);
         } catch (\Aws\S3\Exception\S3Exception $e) {
             $errorcode = $e->getAwsErrorCode();
             // Write could have failed.
@@ -368,7 +368,7 @@ class client extends object_client_base {
             try {
                 $result = $this->client->deleteObject([
                     'Bucket' => $this->bucket,
-                    'Key' => $this->bucketkeyprefix . 'permissions_check_file'
+                    'Key' => $this->bucketkeyprefix . 'permissions_check_file',
                 ]);
                 $permissions->messages[get_string('settings:deletesuccess', 'tool_objectfs')] = 'warning';
                 $permissions->success = false;
@@ -536,7 +536,7 @@ class client extends object_client_base {
      * @return signed_url
      * @throws \Exception
      */
-    public function generate_presigned_url($contenthash, $headers = array()) {
+    public function generate_presigned_url($contenthash, $headers = []) {
         if ('cf' === $this->signingmethod) {
             return  $this->generate_presigned_url_cloudfront($contenthash, $headers);
         }
@@ -825,18 +825,18 @@ class client extends object_client_base {
         } catch (\Exception $e) {
             throw new \coding_exception('Failed to generate pre-signed url: ' . $e->getMessage());
         }
-        $headers = array(
+        $headers = [
             'Range: bytes=' . $ranges->rangefrom . '-' . $ranges->rangeto,
-        );
+        ];
         $curl = new \curl();
-        $curl->setopt(array('CURLOPT_HTTP_VERSION' => CURL_HTTP_VERSION_1_1));
-        $curl->setopt(array('CURLOPT_RETURNTRANSFER' => true));
-        $curl->setopt(array('CURLOPT_SSL_VERIFYPEER' => false));
-        $curl->setopt(array('CURLOPT_CONNECTTIMEOUT' => 15));
-        $curl->setopt(array('CURLOPT_TIMEOUT' => 15));
+        $curl->setopt(['CURLOPT_HTTP_VERSION' => CURL_HTTP_VERSION_1_1]);
+        $curl->setopt(['CURLOPT_RETURNTRANSFER' => true]);
+        $curl->setopt(['CURLOPT_SSL_VERIFYPEER' => false]);
+        $curl->setopt(['CURLOPT_CONNECTTIMEOUT' => 15]);
+        $curl->setopt(['CURLOPT_TIMEOUT' => 15]);
         $curl->setHeader($headers);
         $content = $curl->get($url);
-        return array('responseheaders' => $curl->getResponse(), 'content' => $content, 'url' => $url);
+        return ['responseheaders' => $curl->getResponse(), 'content' => $content, 'url' => $url];
     }
 
     /**

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -667,7 +667,13 @@ class client extends object_client_base {
 
             if (!empty($originalfilename)) {
                 $result['Content-Disposition'] = $contentdisposition;
-                $result['filename'] = 'filename="' . utf8_encode($originalfilename) . '"';
+                // The filename parameter must be in ISO-8859-1, however it works in browsers if
+                // you treat the original UTF-8 string as ISO-8859-1 characters. To achieve that
+                // here, we encode the UTF-8 as if it were ISO-8859-1. This behaviour is hideous
+                // so it would be nice to use the optional filename* field (RFC 5987) but S3 still
+                // complains if we do that.
+                $jankyfilename = \core_text::convert($originalfilename, 'ISO-8859-1');
+                $result['filename'] = 'filename="' . $jankyfilename . '"';
                 $result['Content-Type'] = $originalcontenttype;
             }
         }

--- a/classes/local/store/swift/client.php
+++ b/classes/local/store/swift/client.php
@@ -70,7 +70,7 @@ class client extends object_client_base {
                 'password' => $this->config->openstack_password,
                 'domain' => ['id' => 'default'],
             ],
-            'scope'   => ['project' => ['id' => $this->config->openstack_projectid]]
+            'scope'   => ['project' => ['id' => $this->config->openstack_projectid]],
         ];
 
         if (!isset($this->config->openstack_authtoken['expires_at'])
@@ -179,7 +179,7 @@ class client extends object_client_base {
                 'endpoint' => $this->config->openstack_authurl,
                 'region' => $this->config->openstack_region,
                 'cachedtoken' => $this->config->openstack_authtoken,
-            ]
+            ],
         ]);
         return $context;
     }
@@ -288,7 +288,7 @@ class client extends object_client_base {
     public function test_permissions($testdelete) {
         $permissions = new \stdClass();
         $permissions->success = true;
-        $permissions->messages = array();
+        $permissions->messages = [];
 
         $container = $this->get_container();
 

--- a/classes/log/aggregate_logger.php
+++ b/classes/log/aggregate_logger.php
@@ -25,7 +25,7 @@
 
 namespace tool_objectfs\log;
 
-use \tool_objectfs\log\objectfs_statistic;
+use tool_objectfs\log\objectfs_statistic;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -64,14 +64,14 @@ class aggregate_logger extends objectfs_logger {
      */
     public function __construct() {
         parent::__construct();
-        $this->movestatistics = array(
-            OBJECT_LOCATION_ERROR => array(),
-            OBJECT_LOCATION_LOCAL => array(),
-            OBJECT_LOCATION_DUPLICATED => array(),
-            OBJECT_LOCATION_EXTERNAL => array()
-        );
-        $this->readstatistics = array();
-        $this->querystatistics = array();
+        $this->movestatistics = [
+            OBJECT_LOCATION_ERROR => [],
+            OBJECT_LOCATION_LOCAL => [],
+            OBJECT_LOCATION_DUPLICATED => [],
+            OBJECT_LOCATION_EXTERNAL => [],
+        ];
+        $this->readstatistics = [];
+        $this->querystatistics = [];
     }
 
     /**

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -23,13 +23,11 @@
  */
 namespace tool_objectfs\privacy;
 use core_privacy\local\metadata\null_provider;
-use core_privacy\local\legacy_polyfill;
 /**
  * Class provider
  * @package tool_objectfs
  */
 class provider implements null_provider {
-    use legacy_polyfill;
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.

--- a/classes/task/delete_orphaned_object_metadata.php
+++ b/classes/task/delete_orphaned_object_metadata.php
@@ -54,7 +54,7 @@ class delete_orphaned_object_metadata extends task {
 
         $params = [
             'location' => OBJECT_LOCATION_ORPHANED,
-            'ageforremoval' => time() - $ageforremoval
+            'ageforremoval' => time() - $ageforremoval,
         ];
 
         if (!empty($this->config->deleteexternal) && $this->config->deleteexternal == TOOL_OBJECTFS_DELETE_EXTERNAL_TRASH) {

--- a/classes/tests/testcase.php
+++ b/classes/tests/testcase.php
@@ -66,7 +66,7 @@ abstract class testcase extends \advanced_testcase {
         $itemid    = 0;
         $filepath  = '/';
         $sourcefield = 'Copyright stuff';
-        $filerecord = array(
+        $filerecord = [
             'contextid' => $syscontext->id,
             'component' => $component,
             'filearea'  => $filearea,
@@ -75,7 +75,7 @@ abstract class testcase extends \advanced_testcase {
             'filename'  => $pathname,
             'source'    => $sourcefield,
             'mimetype'  => 'text',
-        );
+        ];
         $file = $fs->create_file_from_pathname($filerecord, $pathname);
 
         manager::update_object_by_hash($file->get_contenthash(), OBJECT_LOCATION_LOCAL);
@@ -96,7 +96,7 @@ abstract class testcase extends \advanced_testcase {
         $itemid    = 0;
         $filepath  = '/';
         $sourcefield = 'Copyright stuff';
-        $filerecord = array(
+        $filerecord = [
             'contextid' => $syscontext->id,
             'component' => $component,
             'filearea'  => $filearea,
@@ -105,7 +105,7 @@ abstract class testcase extends \advanced_testcase {
             'filename'  => md5($content), // Unqiue content should guarentee unique path.
             'source'    => $sourcefield,
             'mimetype'  => 'text',
-        );
+        ];
         $file = $fs->create_file_from_string($filerecord, $content);
 
         manager::update_object_by_hash($file->get_contenthash(), OBJECT_LOCATION_LOCAL);
@@ -325,7 +325,7 @@ abstract class testcase extends \advanced_testcase {
      */
     protected function delete_draft_files($contenthash) {
         global $DB;
-        $DB->delete_records('files', array('contenthash' => $contenthash));
+        $DB->delete_records('files', ['contenthash' => $contenthash]);
     }
 
     /**

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -25,87 +25,87 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$tasks = array(
-    array(
+$tasks = [
+    [
         'classname' => 'tool_objectfs\task\push_objects_to_storage',
         'blocking'  => 0,
         'minute'    => '*',
         'hour'      => '*',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\generate_status_report',
         'blocking'  => 0,
         'minute'    => '17',
         'hour'     => '*',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\delete_local_objects',
         'blocking'  => 0,
         'minute'    => '*',
         'hour'      => '*',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\orphan_objects',
         'blocking'  => 0,
         'minute'    => 'R',
         'hour'      => 'R',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\delete_orphaned_object_metadata',
         'blocking'  => 0,
         'minute'    => 'R',
         'hour'      => 'R',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\delete_local_empty_directories',
         'blocking'  => 0,
         'minute'    => '0',
         'hour'      => '1',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\pull_objects_from_storage',
         'blocking'  => 0,
         'minute'    => '*',
         'hour'      => '*',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\recover_error_objects',
         'blocking'  => 0,
         'minute'    => '34',
         'hour'      => '*/12',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\check_objects_location',
         'blocking'  => 0,
         'minute'    => 'R',
         'hour'      => '*',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-);
+        'month'     => '*',
+    ],
+];
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -51,7 +51,7 @@ function xmldb_tool_objectfs_upgrade($oldversion) {
 
     if ($oldversion < 2017031000) {
         $table = new xmldb_table('tool_objectfs_objects');
-        $key = new xmldb_key('contenthash', XMLDB_KEY_UNIQUE, array('contenthash'));
+        $key = new xmldb_key('contenthash', XMLDB_KEY_UNIQUE, ['contenthash']);
         $dbman->add_key($table, $key);
 
         upgrade_plugin_savepoint(true, 2017031000, 'tool', 'objectfs');
@@ -111,7 +111,7 @@ function xmldb_tool_objectfs_upgrade($oldversion) {
         $table = new xmldb_table('tool_objectfs_reports');
         $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE);
         $table->add_field('reportdate', XMLDB_TYPE_INTEGER, 10, null, XMLDB_NOTNULL);
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
         $table->add_index('reportdate_idx', XMLDB_INDEX_NOTUNIQUE, ['reportdate']);
         if (!$dbman->table_exists($table)) {
             $dbman->create_table($table);
@@ -124,7 +124,7 @@ function xmldb_tool_objectfs_upgrade($oldversion) {
         $table->add_field('datakey', XMLDB_TYPE_CHAR, 15, null, XMLDB_NOTNULL);
         $table->add_field('objectcount', XMLDB_TYPE_INTEGER, 15, null, XMLDB_NOTNULL);
         $table->add_field('objectsum', XMLDB_TYPE_INTEGER, 20, null, XMLDB_NOTNULL);
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
         $table->add_index('reporttype_idx', XMLDB_INDEX_NOTUNIQUE, ['reporttype']);
         $table->add_index('reportid_idx', XMLDB_INDEX_NOTUNIQUE, ['reportid']);
         if (!$dbman->table_exists($table)) {

--- a/lib.php
+++ b/lib.php
@@ -122,7 +122,7 @@ function tool_objectfs_pluginfile($course, $cm, context $context, $filearea, arr
 function tool_objectfs_status_checks() {
     if (get_config('tool_objectfs', 'proxyrangerequests')) {
         return [
-            new tool_objectfs\check\proxy_range_request()
+            new tool_objectfs\check\proxy_range_request(),
         ];
     }
 

--- a/object_location.php
+++ b/object_location.php
@@ -31,7 +31,7 @@ require_once($CFG->libdir.'/tablelib.php');
 admin_externalpage_setup('tool_objectfs_object_location_history');
 
 $logformat   = optional_param('download', '', PARAM_ALPHA);
-$params = array();
+$params = [];
 if ($logformat) {
     $params['download'] = $logformat;
 }

--- a/renderer.php
+++ b/renderer.php
@@ -79,14 +79,14 @@ class tool_objectfs_renderer extends plugin_renderer_base {
             $itemid = 0;
             $filepath = '/';
 
-            $filerecord = array(
+            $filerecord = [
                 'contextid' => $contextid,
                 'component' => $component,
                 'filearea'  => $filearea,
                 'itemid'    => $itemid,
                 'filepath'  => $filepath,
-                'filename'  => $testfilename
-            );
+                'filename'  => $testfilename,
+            ];
 
             $testfile = $filestorage->get_file($contextid, $component, $filearea, $itemid, $filepath, $testfilename);
             if (!$testfile) {
@@ -236,15 +236,15 @@ class tool_objectfs_renderer extends plugin_renderer_base {
 
         $baseurl = '/admin/tool/objectfs/object_status.php';
 
-        $previd = array();
-        $nextid = array();
-        $prevdisabled = array('disabled' => true);
-        $nextdisabled = array('disabled' => true);
+        $previd = [];
+        $nextid = [];
+        $prevdisabled = ['disabled' => true];
+        $nextdisabled = ['disabled' => true];
 
         end($reports);
-        $oldestid = array('reportid' => key($reports));
+        $oldestid = ['reportid' => key($reports)];
         reset($reports);
-        $latestid = array('reportid' => key($reports));
+        $latestid = ['reportid' => key($reports)];
 
         while ($reportid != key($reports)) {
             next($reports);
@@ -252,7 +252,7 @@ class tool_objectfs_renderer extends plugin_renderer_base {
 
         if (next($reports)) {
             $previd = ['reportid' => key($reports)];
-            $prevdisabled = array();
+            $prevdisabled = [];
             prev($reports);
         } else {
             end($reports);
@@ -260,7 +260,7 @@ class tool_objectfs_renderer extends plugin_renderer_base {
 
         if (prev($reports)) {
             $nextid = ['reportid' => key($reports)];
-            $nextdisabled = array();
+            $nextdisabled = [];
             next($reports);
         } else {
             reset($reports);

--- a/tests/local/manager_test.php
+++ b/tests/local/manager_test.php
@@ -38,7 +38,7 @@ class manager_test extends \tool_objectfs\tests\testcase {
      *
      * @return array
      */
-    public function all_extensions_whitelisted_provider() {
+    public static function all_extensions_whitelisted_provider(): array {
         return [
             [null, false],
             ['', false],
@@ -69,7 +69,7 @@ class manager_test extends \tool_objectfs\tests\testcase {
      *
      * @return array
      */
-    public function is_extension_whitelisted_provider() {
+    public static function is_extension_whitelisted_provider(): array {
         return [
             [null, 'file.tar', false],
             ['', 'file.tar', false],
@@ -103,7 +103,7 @@ class manager_test extends \tool_objectfs\tests\testcase {
      *
      * @return array
      */
-    public function get_header_provider() {
+    public static function get_header_provider(): array {
         return [
             [[], '', ''],
             [[], 'Missing header', ''],

--- a/tests/local/object_manipulator/checker_test.php
+++ b/tests/local/object_manipulator/checker_test.php
@@ -45,7 +45,7 @@ class checker_test extends \tool_objectfs\tests\testcase {
     public function test_checker_get_location_local_if_object_is_local() {
         global $DB;
         $file = $this->create_local_object();
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $file->contenthash]);
         $this->assertEquals('string', gettype($location));
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $location);
     }
@@ -53,7 +53,7 @@ class checker_test extends \tool_objectfs\tests\testcase {
     public function test_checker_get_location_duplicated_if_object_is_duplicated() {
         global $DB;
         $file = $this->create_duplicated_object();
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $file->contenthash]);
         $this->assertEquals('string', gettype($location));
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
     }
@@ -61,7 +61,7 @@ class checker_test extends \tool_objectfs\tests\testcase {
     public function test_checker_get_location_external_if_object_is_external() {
         global $DB;
         $file = $this->create_remote_object();
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $file->contenthash]);
         $this->assertEquals('string', gettype($location));
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
     }
@@ -79,7 +79,7 @@ class checker_test extends \tool_objectfs\tests\testcase {
     public function test_checker_get_candidate_objects_will_get_object() {
         global $DB;
         $localobject = $this->create_local_object('test_checker_get_candidate_objects_will_get_object');
-        $DB->delete_records('tool_objectfs_objects', array('contenthash' => $localobject->contenthash));
+        $DB->delete_records('tool_objectfs_objects', ['contenthash' => $localobject->contenthash]);
 
         self::assertTrue($this->objects_contain_hash($localobject->contenthash));
     }
@@ -101,27 +101,27 @@ class checker_test extends \tool_objectfs\tests\testcase {
         $file = $this->create_local_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $this->assertEquals(OBJECT_LOCATION_LOCAL, $reflection->invokeArgs($this->checker, array($file)));
+        $this->assertEquals(OBJECT_LOCATION_LOCAL, $reflection->invokeArgs($this->checker, [$file]));
     }
 
     public function test_checker_manipulate_object_method_will_get_correct_location_if_file_is_duplicated() {
         $file = $this->create_duplicated_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $reflection->invokeArgs($this->checker, array($file)));
+        $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $reflection->invokeArgs($this->checker, [$file]));
     }
 
     public function test_checker_manipulate_object_method_will_get_correct_location_if_file_is_external() {
         $file = $this->create_remote_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $reflection->invokeArgs($this->checker, array($file)));
+        $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $reflection->invokeArgs($this->checker, [$file]));
     }
 
     public function test_checker_manipulate_object_method_will_get_error_location_on_error_file() {
         $file = $this->create_error_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $this->assertEquals(OBJECT_LOCATION_ERROR, $reflection->invokeArgs($this->checker, array($file)));
+        $this->assertEquals(OBJECT_LOCATION_ERROR, $reflection->invokeArgs($this->checker, [$file]));
     }
 }

--- a/tests/local/object_manipulator/deleter_test.php
+++ b/tests/local/object_manipulator/deleter_test.php
@@ -84,9 +84,9 @@ class deleter_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_duplicated_object();
 
-        $this->deleter->execute(array($object));
+        $this->deleter->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
         $this->assertFalse($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -96,9 +96,9 @@ class deleter_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_local_object();
 
-        $this->deleter->execute(array($object));
+        $this->deleter->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertFalse($this->is_externally_readable_by_hash($object->contenthash));
@@ -108,9 +108,9 @@ class deleter_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_remote_object();
 
-        $this->deleter->execute(array($object));
+        $this->deleter->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
         $this->assertFalse($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -121,9 +121,9 @@ class deleter_test extends \tool_objectfs\tests\testcase {
         $object = $this->create_duplicated_object();
         $this->set_deleter_config('deletelocal', 0);
 
-        $this->deleter->execute(array($object));
+        $this->deleter->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -131,7 +131,7 @@ class deleter_test extends \tool_objectfs\tests\testcase {
 
     public function test_deleter_can_delete_multiple_objects() {
         global $DB;
-        $objects = array();
+        $objects = [];
         for ($i = 0; $i < 5; $i++) {
             $objects[] = $this->create_duplicated_object("Object $i");
         }
@@ -139,7 +139,7 @@ class deleter_test extends \tool_objectfs\tests\testcase {
         $this->deleter->execute($objects);
 
         foreach ($objects as $object) {
-            $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+            $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
             $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
             $this->assertFalse($this->is_locally_readable_by_hash($object->contenthash));
             $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));

--- a/tests/local/object_manipulator/orphaner_test.php
+++ b/tests/local/object_manipulator/orphaner_test.php
@@ -93,7 +93,7 @@ class orphaner_test extends \tool_objectfs\tests\testcase {
 
         // Update that object to have a different hash, to mock a non-existent
         // mdl_file with an objectfs record (orphaned).
-        $DB->set_field('files', 'contenthash', 'different', array('contenthash' => $object->contenthash));
+        $DB->set_field('files', 'contenthash', 'different', ['contenthash' => $object->contenthash]);
 
         // Expect one candidate - no matching contenthash in {files}.
         $objects = $finder->get();

--- a/tests/local/object_manipulator/puller_test.php
+++ b/tests/local/object_manipulator/puller_test.php
@@ -74,7 +74,7 @@ class puller_test extends \tool_objectfs\tests\testcase {
     public function test_puller_get_candidate_objects_will_not_get_objects_over_sizethreshold() {
         global $DB;
         $remoteobject = $this->create_remote_object();
-        $DB->set_field('files', 'filesize', 10, array('contenthash' => $remoteobject->contenthash));
+        $DB->set_field('files', 'filesize', 10, ['contenthash' => $remoteobject->contenthash]);
         $this->set_puller_config('sizethreshold', 0);
 
         self::assertFalse($this->objects_contain_hash($remoteobject->contenthash));
@@ -84,9 +84,9 @@ class puller_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_remote_object();
 
-        $this->puller->execute(array($object));
+        $this->puller->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -96,9 +96,9 @@ class puller_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_duplicated_object();
 
-        $this->puller->execute(array($object));
+        $this->puller->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -108,9 +108,9 @@ class puller_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_local_object();
 
-        $this->puller->execute(array($object));
+        $this->puller->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertFalse($this->is_externally_readable_by_hash($object->contenthash));

--- a/tests/local/object_manipulator/pusher_test.php
+++ b/tests/local/object_manipulator/pusher_test.php
@@ -77,7 +77,7 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_local_object();
         $maximumfilesize = $this->filesystem->get_maximum_upload_filesize() + 1;
-        $DB->set_field('tool_objectfs_objects', 'filesize', $maximumfilesize, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'filesize', $maximumfilesize, ['contenthash' => $object->contenthash]);
 
         self::assertFalse($this->objects_contain_hash($object->contenthash));
     }
@@ -86,7 +86,7 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $this->set_pusher_config('sizethreshold', 100);
         $object = $this->create_local_object();
-        $DB->set_field('tool_objectfs_objects', 'filesize', 10, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'filesize', 10, ['contenthash' => $object->contenthash]);
 
         self::assertFalse($this->objects_contain_hash($object->contenthash));
     }
@@ -102,9 +102,9 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_local_object();
 
-        $this->pusher->execute(array($object));
+        $this->pusher->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -114,9 +114,9 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_duplicated_object();
 
-        $this->pusher->execute(array($object));
+        $this->pusher->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -126,9 +126,9 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_remote_object();
 
-        $this->pusher->execute(array($object));
+        $this->pusher->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
         $this->assertFalse($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -136,7 +136,7 @@ class pusher_test extends \tool_objectfs\tests\testcase {
 
     public function test_pusher_can_push_multiple_objects() {
         global $DB;
-        $objects = array();
+        $objects = [];
         for ($i = 0; $i < 5; $i++) {
             $objects[] = $this->create_local_object("Object $i");
         }
@@ -144,7 +144,7 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         $this->pusher->execute($objects);
 
         foreach ($objects as $object) {
-            $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+            $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
             $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
             $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
             $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -161,7 +161,7 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         $this->pusher->execute($objects);
 
         $object = $this->create_local_object();
-        $file = $DB->get_record('files', array('contenthash' => $object->contenthash));
+        $file = $DB->get_record('files', ['contenthash' => $object->contenthash]);
 
         // Update mimetype to something different and insert as new file.
         $file->mimetype = "differentMimeType";

--- a/tests/local/object_manipulator/recoverer_test.php
+++ b/tests/local/object_manipulator/recoverer_test.php
@@ -53,44 +53,44 @@ class recoverer_test extends \tool_objectfs\tests\testcase {
     public function test_recoverer_will_recover_local_objects() {
         global $DB;
         $object = $this->create_local_object();
-        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, ['contenthash' => $object->contenthash]);
 
-        $this->recoverer->execute(array($object));
+        $this->recoverer->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $location);
     }
 
     public function test_recoverer_will_recover_duplicated_objects() {
         global $DB;
         $object = $this->create_duplicated_object();
-        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, ['contenthash' => $object->contenthash]);
 
-        $this->recoverer->execute(array($object));
+        $this->recoverer->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
     }
 
     public function test_recoverer_will_recover_remote_objects() {
         global $DB;
         $object = $this->create_remote_object();
-        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, ['contenthash' => $object->contenthash]);
 
-        $this->recoverer->execute(array($object));
+        $this->recoverer->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
     }
 
     public function test_recoverer_will_not_recover_error_objects() {
         global $DB;
         $object = $this->create_error_object();
-        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, ['contenthash' => $object->contenthash]);
 
-        $this->recoverer->execute(array($object));
+        $this->recoverer->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_ERROR, $location);
     }
 }

--- a/tests/local/report/object_status_test.php
+++ b/tests/local/report/object_status_test.php
@@ -168,7 +168,7 @@ class object_status_test extends \tool_objectfs\tests\testcase {
      *
      * @return array
      */
-    public function object_status_add_barchart_method_provider() {
+    public static function object_status_add_barchart_method_provider(): array {
         return [
             [0, 0, '', 0, '0'],
             [0, 100, 'count', 0, '<div class="ofs-bar" style="width:0%">' . number_format(0) . '</div>'],
@@ -212,7 +212,7 @@ class object_status_test extends \tool_objectfs\tests\testcase {
      *
      * @return array
      */
-    public function object_status_get_size_range_from_logsize_provider() {
+    public static function object_status_get_size_range_from_logsize_provider(): array {
         return [
             ['1', '< ' . display_size(1024)],
             ['10', display_size(1024) . ' - ' . display_size(2048)],

--- a/tests/local/store/clients_test.php
+++ b/tests/local/store/clients_test.php
@@ -16,8 +16,8 @@
 
 namespace tool_objectfs\local\store;
 
-use \tool_objectfs\tests\test_digitalocean_integration_client as digitaloceanclient;
-use \tool_objectfs\tests\test_s3_integration_client as s3client;
+use tool_objectfs\tests\test_digitalocean_integration_client as digitaloceanclient;
+use tool_objectfs\tests\test_s3_integration_client as s3client;
 
 /**
  * Client tests.
@@ -32,7 +32,7 @@ class clients_test extends \advanced_testcase {
      *
      * @return \array[][]
      */
-    public function s3_client_test_connection_if_not_configured_properly_data_provider() {
+    public static function s3_client_test_connection_if_not_configured_properly_data_provider(): array {
         return [
             [[]],
             [['s3_bucket' => '', 's3_region' => 'test', 's3_usesdkcreds' => 0, 's3_key' => 'test', 's3_secret' => 'test']],
@@ -72,7 +72,7 @@ class clients_test extends \advanced_testcase {
      *
      * @return \array[][]
      */
-    public function digitalocean_client_test_connection_if_not_configured_properly_data_provider() {
+    public static function digitalocean_client_test_connection_if_not_configured_properly_data_provider(): array {
         return [
             [[]],
             [['do_key' => '', 'do_secret' => '', 'do_region' => '']],

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -234,7 +234,7 @@ class object_file_system_test extends tests\testcase {
      * delete_empty_folders_provider
      * @return array
      */
-    public function delete_empty_folders_provider() {
+    public static function delete_empty_folders_provider(): array {
         return [
             [
                 /*
@@ -334,11 +334,11 @@ class object_file_system_test extends tests\testcase {
 
         // Phpunit will fail if PHP warning is thrown (which we want)
         // so we surpress here.
-        set_error_handler(array($this, 'error_surpressor'));
+        set_error_handler([$this, 'error_surpressor']);
         $this->filesystem->readfile($fakefile);
         restore_error_handler();
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $fakefile->get_contenthash()));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $fakefile->get_contenthash()]);
         $this->assertEquals(OBJECT_LOCATION_ERROR, $location);
     }
 
@@ -366,11 +366,11 @@ class object_file_system_test extends tests\testcase {
 
         // Phpunit will fail if PHP warning is thrown (which we want)
         // so we surpress here.
-        set_error_handler(array($this, 'error_surpressor'));
+        set_error_handler([$this, 'error_surpressor']);
         $this->filesystem->get_content($fakefile);
         restore_error_handler();
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $fakefile->get_contenthash()));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $fakefile->get_contenthash()]);
         $this->assertEquals(OBJECT_LOCATION_ERROR, $location);
     }
 
@@ -389,11 +389,11 @@ class object_file_system_test extends tests\testcase {
 
         // Phpunit will fail if PHP warning is thrown (which we want)
         // so we surpress here.
-        set_error_handler(array($this, 'error_surpressor'));
+        set_error_handler([$this, 'error_surpressor']);
         $this->filesystem->xsendfile($fakefile->get_contenthash());
         restore_error_handler();
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $fakefile->get_contenthash()));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $fakefile->get_contenthash()]);
         $this->assertEquals(OBJECT_LOCATION_ERROR, $location);
     }
 
@@ -429,11 +429,11 @@ class object_file_system_test extends tests\testcase {
 
         // Phpunit will fail if PHP warning is thrown (which we want)
         // so we surpress here.
-        set_error_handler(array($this, 'error_surpressor'));
+        set_error_handler([$this, 'error_surpressor']);
         $filehandle = $this->filesystem->get_content_file_handle($fakefile);
         restore_error_handler();
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $fakefile->get_contenthash()));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $fakefile->get_contenthash()]);
         $this->assertEquals(OBJECT_LOCATION_ERROR, $location);
     }
 
@@ -443,7 +443,7 @@ class object_file_system_test extends tests\testcase {
         $filehash = $file->get_contenthash();
 
         // Delete file record so remove file will remove.
-        $DB->delete_records('files', array('contenthash' => $filehash));
+        $DB->delete_records('files', ['contenthash' => $filehash]);
         $this->filesystem->remove_file($filehash);
 
         $islocalreadable = $this->filesystem->is_file_readable_locally_by_hash($filehash);
@@ -456,7 +456,7 @@ class object_file_system_test extends tests\testcase {
         $filehash = $file->get_contenthash();
 
         // Delete file record so remove file will remove.
-        $DB->delete_records('files', array('contenthash' => $filehash));
+        $DB->delete_records('files', ['contenthash' => $filehash]);
         $this->filesystem->remove_file($filehash);
 
         $isremotereadable = $this->is_externally_readable_by_hash($filehash);
@@ -654,40 +654,40 @@ class object_file_system_test extends tests\testcase {
      * presigned_url_should_redirect_provider
      * @return array
      */
-    public function presigned_url_should_redirect_provider() {
-        $provider = array();
+    public static function presigned_url_should_redirect_provider(): array {
+        $provider = [];
 
         // Testing defaults.
-        $provider[] = array('Default', 'Default', false);
+        $provider[] = ['Default', 'Default', false];
 
         // Testing $enablepresignedurls.
-        $provider[] = array(1, 'Default', true);
-        $provider[] = array('1', 'Default', true);
-        $provider[] = array(0, 'Default', false);
-        $provider[] = array('0', 'Default', false);
-        $provider[] = array('', 'Default', false);
-        $provider[] = array(null, 'Default', false);
+        $provider[] = [1, 'Default', true];
+        $provider[] = ['1', 'Default', true];
+        $provider[] = [0, 'Default', false];
+        $provider[] = ['0', 'Default', false];
+        $provider[] = ['', 'Default', false];
+        $provider[] = [null, 'Default', false];
 
         // Testing $presignedminfilesize.
-        $provider[] = array(1, 0, true);
-        $provider[] = array(1, '0', true);
-        $provider[] = array(1, '', true);
+        $provider[] = [1, 0, true];
+        $provider[] = [1, '0', true];
+        $provider[] = [1, '', true];
 
         // Testing minimum file size to be greater than file size.
         // 12 is a size of the file with 'test content' content.
-        $provider[] = array(1, 13, false);
-        $provider[] = array(1, '13', false);
+        $provider[] = [1, 13, false];
+        $provider[] = [1, '13', false];
 
         // Testing minimum file size to be less than file size.
         // 12 is a size of the file with 'test content' content.
-        $provider[] = array(1, 11, true);
-        $provider[] = array(1, '11', true);
+        $provider[] = [1, 11, true];
+        $provider[] = [1, '11', true];
 
         // Testing nulls and empty strings.
-        $provider[] = array(null, null, false);
-        $provider[] = array(null, '', false);
-        $provider[] = array('', null, false);
-        $provider[] = array('', '', false);
+        $provider[] = [null, null, false];
+        $provider[] = [null, '', false];
+        $provider[] = ['', null, false];
+        $provider[] = ['', '', false];
 
         return $provider;
     }
@@ -733,7 +733,7 @@ class object_file_system_test extends tests\testcase {
      *
      * @return array
      */
-    public function get_expiration_time_method_if_supported_provider() {
+    public static function get_expiration_time_method_if_supported_provider(): array {
         $now = time();
 
         // Seconds after the minute from X.
@@ -840,7 +840,7 @@ class object_file_system_test extends tests\testcase {
      *
      * @return array
      */
-    public function get_valid_http_ranges_provider() {
+    public static function get_valid_http_ranges_provider(): array {
         return [
             ['', 0, false],
             ['bytes=0-', 100, (object)['rangefrom' => 0, 'rangeto' => 99, 'length' => 100]],
@@ -870,7 +870,7 @@ class object_file_system_test extends tests\testcase {
      *
      * @return array
      */
-    public function curl_range_request_to_presigned_url_provider() {
+    public static function curl_range_request_to_presigned_url_provider(): array {
         return [
             ['15-bytes string', (object)['rangefrom' => 0, 'rangeto' => 14, 'length' => 15], '15-bytes string'],
             ['15-bytes string', (object)['rangefrom' => 0, 'rangeto' => 9, 'length' => 10], '15-bytes s'],

--- a/tests/task/populate_objects_filesize_test.php
+++ b/tests/task/populate_objects_filesize_test.php
@@ -44,7 +44,7 @@ class populate_objects_filesize_test extends \tool_objectfs\tests\testcase {
             $this->create_local_file("Test 2")->get_contenthash(),
             $this->create_local_file("Test 3")->get_contenthash(),
             $this->create_local_file("Test 4")->get_contenthash(),
-            $this->create_local_file("This is a looong name")->get_contenthash()
+            $this->create_local_file("This is a looong name")->get_contenthash(),
         ];
 
         // Set all objects to have a filesize of null.
@@ -131,7 +131,7 @@ class populate_objects_filesize_test extends \tool_objectfs\tests\testcase {
             $this->create_local_file("Test 2")->get_contenthash(),
             $this->create_local_file("Test 3")->get_contenthash(),
             $this->create_local_file("Test 4")->get_contenthash(),
-            $this->create_local_file("This is a looong name")->get_contenthash()
+            $this->create_local_file("This is a looong name")->get_contenthash(),
         ];
 
         // Set all objects to have a filesize of null.


### PR DESCRIPTION
**Changes**
- Cleanup all coding standards and phpdoc warnings. Mostly done via `phpcbf` + manually converting unit test providers to static functions (after confirming they are truly static, just weren't labelled as such)
- Removes use of deprecated `utf_encode` - cherry picked commit from here https://github.com/catalyst/moodle-tool_objectfs/pull/598 - tested in S3 myself, and S3 + cloudfront in the other PR and works as expected, seems equivalent.
- Removed [legacy privacy api polyfill](https://moodledev.io/docs/4.4/apis/subsystems/privacy#what-to-do-if-you-have-one-plugin-that-supports-multiple-branches) needed because older php versions didn't support typehinting, however, Moodle 3.10 supports Php 7.2 which supports type hinting (params and return types)

**To Do**
- [x] Test  `utf8_encode` replacement and confirm it still works as expected
- [x] Port to MOODLE_402_STABLE as well https://github.com/catalyst/moodle-tool_objectfs/pull/622