### PR TITLE
Fix PHP 8.2 deprecation warnings in unit tests (4.2)

### DIFF
--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -48,6 +48,9 @@ class client extends object_client_base {
     protected $bucket;
     private $signingmethod;
 
+    /** @var string Prefix for bucket keys */
+    protected $bucketkeyprefix;
+
     public function __construct($config) {
         global $CFG;
         $this->autoloader = $CFG->dirroot . '/local/aws/sdk/aws-autoloader.php';

--- a/classes/tests/testcase.php
+++ b/classes/tests/testcase.php
@@ -27,6 +27,12 @@ use tool_objectfs\local\store\signed_url;
 
 abstract class testcase extends \advanced_testcase {
 
+    /** @var test_file_system Filesystem */
+    public $filesystem;
+
+    /** @var \tool_objectfs\log\objectfs_logger Logger */
+    public $logger;
+
     protected function setUp(): void {
         global $CFG;
         $CFG->alternative_file_system_class = '\\tool_objectfs\\tests\\test_file_system';

--- a/tests/local/object_manipulator/checker_test.php
+++ b/tests/local/object_manipulator/checker_test.php
@@ -28,6 +28,9 @@ class checker_test extends \tool_objectfs\tests\testcase {
     /** @var string $manipulator */
     protected $manipulator = checker::class;
 
+    /** @var checker Checker */
+    protected $checker;
+
     protected function setUp(): void {
         parent::setUp();
         $config = manager::get_objectfs_config();

--- a/tests/local/object_manipulator/deleter_test.php
+++ b/tests/local/object_manipulator/deleter_test.php
@@ -28,6 +28,9 @@ class deleter_test extends \tool_objectfs\tests\testcase {
     /** @var string $manipulator */
     protected $manipulator = deleter::class;
 
+    /** @var deleter Deleter object */
+    protected $deleter;
+
     protected function setUp(): void {
         parent::setUp();
         $config = manager::get_objectfs_config();

--- a/tests/local/object_manipulator/orphaner_test.php
+++ b/tests/local/object_manipulator/orphaner_test.php
@@ -29,6 +29,9 @@ class orphaner_test extends \tool_objectfs\tests\testcase {
     /** @var string $manipulator */
     protected $manipulator = orphaner::class;
 
+    /** @var orphaner Orphaner object */
+    protected $orphaner;
+
     protected function setUp(): void {
         parent::setUp();
         $config = manager::get_objectfs_config();

--- a/tests/local/object_manipulator/puller_test.php
+++ b/tests/local/object_manipulator/puller_test.php
@@ -28,6 +28,9 @@ class puller_test extends \tool_objectfs\tests\testcase {
     /** @var string $manipulator */
     protected $manipulator = puller::class;
 
+    /** @var puller Puller object */
+    protected $puller;
+
     protected function setUp(): void {
         parent::setUp();
         $config = manager::get_objectfs_config();

--- a/tests/local/object_manipulator/pusher_test.php
+++ b/tests/local/object_manipulator/pusher_test.php
@@ -29,6 +29,9 @@ class pusher_test extends \tool_objectfs\tests\testcase {
     /** @var string $manipulator */
     protected $manipulator = pusher::class;
 
+    /** @var pusher Pusher object */
+    protected $pusher;
+
     protected function setUp(): void {
         parent::setUp();
         $config = manager::get_objectfs_config();

--- a/tests/local/object_manipulator/recoverer_test.php
+++ b/tests/local/object_manipulator/recoverer_test.php
@@ -26,6 +26,12 @@ use tool_objectfs\local\object_manipulator\candidates\candidates_finder;
  */
 class recoverer_test extends \tool_objectfs\tests\testcase {
 
+    /** @var candidates_finder Candidates finder object */
+    protected $candidatesfinder;
+
+    /** @var recoverer Recoverer object */
+    protected $recoverer;
+
     protected function setUp(): void {
         parent::setUp();
         $config = manager::get_objectfs_config();


### PR DESCRIPTION
There were a number of 'Creation of dynamic property...' deprecation warnings when running the unit test. These happen if you set '$this->field = value' without declaring e.g. 'protected $field' in the class.

I've fixed these and the unit tests now run for me. The fix should be safe for all recent PHP versions, i.e. I didn't add types to the declarations.

This is just a MOODLE_402 branch version of #586.