### PR TITLE
Fix codestandards 402

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,5 +6,3 @@ on: [push, pull_request]
 jobs:
   ci:
     uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
-    with:
-      disable_phpdoc: true

--- a/classes/azure_file_system.php
+++ b/classes/azure_file_system.php
@@ -27,6 +27,9 @@ namespace tool_objectfs;
 
 use tool_objectfs\local\store\azure\file_system;
 
+/**
+ * Unknown?
+ */
 class azure_file_system extends file_system {
 
 }

--- a/classes/digitalocean_file_system.php
+++ b/classes/digitalocean_file_system.php
@@ -19,6 +19,7 @@
  *
  * @package   tool_objectfs
  * @author    Brian Yanosik <kisonay@gmail.com>
+ * @copyright  Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -26,6 +27,9 @@ namespace tool_objectfs;
 
 use tool_objectfs\local\store\digitalocean\file_system;
 
+/**
+ * Unknown?
+ */
 class digitalocean_file_system extends file_system {
 
 }

--- a/classes/local/manager.php
+++ b/classes/local/manager.php
@@ -28,12 +28,15 @@ namespace tool_objectfs\local;
 use stdClass;
 use tool_objectfs\local\store\object_file_system;
 
-defined('MOODLE_INTERNAL') || die();
-
+/**
+ * [Description manager]
+ */
 class manager {
 
     /**
-     * @param $config
+     * set_objectfs_config
+     * @param stdClass $config
+     * @return void
      */
     public static function set_objectfs_config($config) {
         foreach ($config as $key => $value) {
@@ -42,6 +45,7 @@ class manager {
     }
 
     /**
+     * get_objectfs_config
      * @return stdClass
      * @throws \dml_exception
      */
@@ -114,8 +118,9 @@ class manager {
     }
 
     /**
-     * @param $config
-     * @return bool
+     * get_client
+     * @param stdClass $config
+     * @return mixed|bool
      */
     public static function get_client($config) {
         $clientclass = self::get_client_classname_from_fs($config->filesystem);
@@ -128,8 +133,9 @@ class manager {
     }
 
     /**
-     * @param $contenthash
-     * @param $newlocation
+     * update_object_by_hash
+     * @param string $contenthash
+     * @param string $newlocation
      * @param int|null $filesize Size of the file in bytes. Falls back to stored value if not provided.
      * @return mixed|stdClass
      * @throws \dml_exception
@@ -172,8 +178,9 @@ class manager {
     }
 
     /**
+     * update_object
      * @param stdClass $object
-     * @param $newlocation
+     * @param string $newlocation
      * @return stdClass
      * @throws \dml_exception
      */
@@ -192,6 +199,7 @@ class manager {
     }
 
     /**
+     * cloudfront_pem_exists
      * @return string
      * @throws \coding_exception
      * @throws \dml_exception

--- a/classes/local/object_manipulator/candidates/candidates_factory.php
+++ b/classes/local/object_manipulator/candidates/candidates_factory.php
@@ -33,6 +33,9 @@ use tool_objectfs\local\object_manipulator\pusher;
 use tool_objectfs\local\object_manipulator\recoverer;
 use tool_objectfs\local\object_manipulator\orphaner;
 
+/**
+ * Candidates Factory
+ */
 class candidates_factory {
 
     /** @var array $manipulatormap */
@@ -46,8 +49,10 @@ class candidates_factory {
     ];
 
     /**
-     * @param $manipulator
+     * Finder
+     * @param mixed $manipulator
      * @param stdClass $config
+     *
      * @return mixed
      * @throws moodle_exception
      */

--- a/classes/local/object_manipulator/candidates/candidates_finder.php
+++ b/classes/local/object_manipulator/candidates/candidates_finder.php
@@ -27,6 +27,9 @@ namespace tool_objectfs\local\object_manipulator\candidates;
 use moodle_exception;
 use stdClass;
 
+/**
+ * Candidates Finder
+ */
 class candidates_finder {
 
     /** @var string $finder */
@@ -43,6 +46,7 @@ class candidates_finder {
     }
 
     /**
+     * get
      * @return array
      */
     public function get() {
@@ -50,6 +54,7 @@ class candidates_finder {
     }
 
     /**
+     * get_query_name
      * @return string
      */
     public function get_query_name() {

--- a/classes/local/object_manipulator/candidates/checker_candidates.php
+++ b/classes/local/object_manipulator/candidates/checker_candidates.php
@@ -24,13 +24,19 @@
 
 namespace tool_objectfs\local\object_manipulator\candidates;
 
+/**
+ * chcker_candiates
+ */
 class checker_candidates extends  manipulator_candidates_base {
 
-    /** @var string $queryname */
+    /**
+     * queryname
+     * @var string
+     */
     protected $queryname = 'get_check_candidates';
 
     /**
-     * @inheritDoc
+     * get_candiates_sql
      * @return string
      */
     public function get_candidates_sql() {
@@ -43,7 +49,7 @@ class checker_candidates extends  manipulator_candidates_base {
     }
 
     /**
-     * @inheritDoc
+     * get_candidates_sql_params
      * @return array
      */
     public function get_candidates_sql_params() {

--- a/classes/local/object_manipulator/candidates/deleter_candidates.php
+++ b/classes/local/object_manipulator/candidates/deleter_candidates.php
@@ -57,7 +57,7 @@ class deleter_candidates extends manipulator_candidates_base {
         return [
             'consistancythreshold' => $consistancythreshold,
             'location' => OBJECT_LOCATION_DUPLICATED,
-            'sizethreshold' => $this->config->sizethreshold
+            'sizethreshold' => $this->config->sizethreshold,
         ];
     }
 }

--- a/classes/local/object_manipulator/candidates/deleter_candidates.php
+++ b/classes/local/object_manipulator/candidates/deleter_candidates.php
@@ -24,13 +24,19 @@
 
 namespace tool_objectfs\local\object_manipulator\candidates;
 
+/**
+ * deleter_candidates
+ */
 class deleter_candidates extends manipulator_candidates_base {
 
-    /** @var string $queryname */
+    /**
+     * queryname
+     * @var string
+     */
     protected $queryname = 'get_delete_candidates';
 
     /**
-     * @inheritDoc
+     * get_candiates_sql
      * @return string
      */
     public function get_candidates_sql() {
@@ -43,7 +49,7 @@ class deleter_candidates extends manipulator_candidates_base {
     }
 
     /**
-     * @inheritDoc
+     * get_candiates_sql_params
      * @return array
      */
     public function get_candidates_sql_params() {

--- a/classes/local/object_manipulator/candidates/manipulator_candidates.php
+++ b/classes/local/object_manipulator/candidates/manipulator_candidates.php
@@ -50,6 +50,7 @@ interface manipulator_candidates {
     public function get_candidates_sql_params();
 
     /**
+     * get
      * @return array
      * @throws dml_exception
      */

--- a/classes/local/object_manipulator/candidates/manipulator_candidates_base.php
+++ b/classes/local/object_manipulator/candidates/manipulator_candidates_base.php
@@ -27,6 +27,9 @@ namespace tool_objectfs\local\object_manipulator\candidates;
 use dml_exception;
 use stdClass;
 
+/**
+ * manipulator_candidates_base
+ */
 abstract class manipulator_candidates_base implements manipulator_candidates {
 
     /** @var stdClass $config */
@@ -41,7 +44,7 @@ abstract class manipulator_candidates_base implements manipulator_candidates {
     }
 
     /**
-     * @inheritDoc
+     * get_query_name
      * @return string
      */
     public function get_query_name() {
@@ -49,6 +52,7 @@ abstract class manipulator_candidates_base implements manipulator_candidates {
     }
 
     /**
+     * get
      * @return array
      * @throws dml_exception
      */

--- a/classes/local/object_manipulator/candidates/orphaner_candidates.php
+++ b/classes/local/object_manipulator/candidates/orphaner_candidates.php
@@ -24,13 +24,19 @@
 
 namespace tool_objectfs\local\object_manipulator\candidates;
 
+/**
+ * orphaner_candidates
+ */
 class orphaner_candidates extends manipulator_candidates_base {
 
-    /** @var string $queryname */
+    /**
+     * queryname
+     * @var string
+     */
     protected $queryname = 'get_orphan_candidates';
 
     /**
-     * @inheritDoc
+     * get_candidates_sql
      * @return string
      */
     public function get_candidates_sql() {
@@ -42,7 +48,7 @@ class orphaner_candidates extends manipulator_candidates_base {
     }
 
     /**
-     * @inheritDoc
+     * get_candidates_sql_params
      * @return array
      */
     public function get_candidates_sql_params() {

--- a/classes/local/object_manipulator/candidates/orphaner_candidates.php
+++ b/classes/local/object_manipulator/candidates/orphaner_candidates.php
@@ -53,7 +53,7 @@ class orphaner_candidates extends manipulator_candidates_base {
      */
     public function get_candidates_sql_params() {
         return [
-          'location' => OBJECT_LOCATION_ORPHANED
+          'location' => OBJECT_LOCATION_ORPHANED,
         ];
     }
 }

--- a/classes/local/object_manipulator/candidates/puller_candidates.php
+++ b/classes/local/object_manipulator/candidates/puller_candidates.php
@@ -24,13 +24,19 @@
 
 namespace tool_objectfs\local\object_manipulator\candidates;
 
+/**
+ * puller_candidates
+ */
 class puller_candidates extends manipulator_candidates_base {
 
-    /** @var string $queryname */
+    /**
+     * queryname
+     * @var string
+     */
     protected $queryname = 'get_pull_candidates';
 
     /**
-     * @inheritDoc
+     * get_candidates_sql
      * @return string
      */
     public function get_candidates_sql() {
@@ -42,7 +48,7 @@ class puller_candidates extends manipulator_candidates_base {
     }
 
     /**
-     * @inheritDoc
+     * get_candidates_sql_params
      * @return array
      */
     public function get_candidates_sql_params() {

--- a/classes/local/object_manipulator/candidates/pusher_candidates.php
+++ b/classes/local/object_manipulator/candidates/pusher_candidates.php
@@ -24,15 +24,19 @@
 
 namespace tool_objectfs\local\object_manipulator\candidates;
 
-defined('MOODLE_INTERNAL') || die();
-
+/**
+ * pusher_candidates
+ */
 class pusher_candidates extends manipulator_candidates_base {
 
-    /** @var string $queryname */
+    /**
+     * queryname
+     * @var string
+     */
     protected $queryname = 'get_push_candidates';
 
     /**
-     * @inheritDoc
+     * get_candidates_sql
      * @return string
      */
     public function get_candidates_sql() {
@@ -46,7 +50,7 @@ class pusher_candidates extends manipulator_candidates_base {
     }
 
     /**
-     * @inheritDoc
+     * get_candidates_sql_params
      * @return array
      */
     public function get_candidates_sql_params() {

--- a/classes/local/object_manipulator/candidates/recoverer_candidates.php
+++ b/classes/local/object_manipulator/candidates/recoverer_candidates.php
@@ -24,13 +24,19 @@
 
 namespace tool_objectfs\local\object_manipulator\candidates;
 
+/**
+ * recoverer_candidates
+ */
 class recoverer_candidates extends manipulator_candidates_base {
 
-    /** @var string $queryname */
+    /**
+     * queryname
+     * @var string
+     */
     protected $queryname = 'get_recover_candidates';
 
     /**
-     * @inheritDoc
+     * get_candidates_sql
      * @return string
      */
     public function get_candidates_sql() {
@@ -41,7 +47,7 @@ class recoverer_candidates extends manipulator_candidates_base {
     }
 
     /**
-     * @inheritDoc
+     * get_candidates_sql_params
      * @return array
      */
     public function get_candidates_sql_params() {

--- a/classes/local/object_manipulator/checker.php
+++ b/classes/local/object_manipulator/checker.php
@@ -29,6 +29,9 @@ use stdClass;
 use tool_objectfs\local\store\object_file_system;
 use tool_objectfs\log\aggregate_logger;
 
+/**
+ * checker
+ */
 class checker extends manipulator {
 
     /**
@@ -45,6 +48,7 @@ class checker extends manipulator {
     }
 
     /**
+     * manipulate_object
      * @param stdClass $objectrecord
      * @return int
      */

--- a/classes/local/object_manipulator/deleter.php
+++ b/classes/local/object_manipulator/deleter.php
@@ -29,6 +29,9 @@ use stdClass;
 use tool_objectfs\local\store\object_file_system;
 use tool_objectfs\log\aggregate_logger;
 
+/**
+ * deleter
+ */
 class deleter extends manipulator {
 
     /**
@@ -61,6 +64,7 @@ class deleter extends manipulator {
     }
 
     /**
+     * manipulate_object
      * @param stdClass $objectrecord
      * @return int
      */
@@ -70,6 +74,7 @@ class deleter extends manipulator {
     }
 
     /**
+     * manipulator_can_execute
      * @return bool
      */
     protected function manipulator_can_execute() {

--- a/classes/local/object_manipulator/logger.php
+++ b/classes/local/object_manipulator/logger.php
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/* Logs manipulator actions
+/** Logs manipulator actions
  *
  * @package   tool_objectfs
  * @author    Kenneth Hendricks <kennethhendricks@catalyst-au.net>
@@ -28,36 +28,81 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * logger
+ */
 class logger {
 
+    /**
+     * @var [type]
+     */
     private $action; // Which action to log.
+    /**
+     * @var int
+     */
     private $timestart;
+    /**
+     * @var int
+     */
     private $timeend;
+    /**
+     * @var int
+     */
     private $totalfilesize;
+    /**
+     * @var int
+     */
     private $totalfilecount;
 
+    /**
+     * construct
+     */
     public function __construct() {
         $this->totalfilecount = 0;
         $this->totalfilesize = 0;
     }
 
+    /**
+     * start_timing
+     * @return void
+     */
     public function start_timing() {
         $this->timestart = time();
     }
 
+    /**
+     * end_timing
+     * @return void
+     */
     public function end_timing() {
         $this->timeend = time();
     }
 
+    /**
+     * set_action
+     * @param mixed $action
+     *
+     * @return void
+     */
     public function set_action($action) {
         $this->action = $action;
     }
 
+    /**
+     * add_object_manipulation
+     * @param int $filesize
+     *
+     * @return void
+     */
     public function add_object_manipulation($filesize) {
         $this->totalfilesize += $filesize;
         $this->totalfilecount++;
     }
 
+    /**
+     * log_object_manipulation
+     * @return void
+     */
     public function log_object_manipulation() {
         $duration = $this->timestart - $this->timeend;
         $totalfilesize = display_size($this->totalfilesize);
@@ -67,6 +112,12 @@ class logger {
         mtrace($logstring);
     }
 
+    /**
+     * log_object_manipulation_query
+     * @param mixed $totalobjectsfound
+     *
+     * @return void
+     */
     public function log_object_manipulation_query($totalobjectsfound) {
         $duration = $this->timeend - $this->timestart;
         $logstring = "Objectsfs $this->action manipulator took $duration seconds ";

--- a/classes/local/object_manipulator/manipulator.php
+++ b/classes/local/object_manipulator/manipulator.php
@@ -35,6 +35,9 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * manipulator
+ */
 abstract class manipulator implements object_manipulator {
 
     /**
@@ -82,6 +85,7 @@ abstract class manipulator implements object_manipulator {
     }
 
     /**
+     * execute
      * @param array $objectrecords
      * @return mixed|void
      * @throws dml_exception

--- a/classes/local/object_manipulator/manipulator_builder.php
+++ b/classes/local/object_manipulator/manipulator_builder.php
@@ -48,7 +48,7 @@ class manipulator_builder {
         pusher::class,
         recoverer::class,
         checker::class,
-        orphaner::class
+        orphaner::class,
     ];
 
     /** @var string $manipulatorclass */

--- a/classes/local/object_manipulator/manipulator_builder.php
+++ b/classes/local/object_manipulator/manipulator_builder.php
@@ -36,6 +36,9 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . '/../../../lib.php');
 
+/**
+ * manipulator_builder
+ */
 class manipulator_builder {
 
     /** @var array $manipulators */
@@ -64,6 +67,7 @@ class manipulator_builder {
     private $candidates = [];
 
     /**
+     * execute
      * @param string $manipulator
      * @throws coding_exception
      * @throws moodle_exception
@@ -83,6 +87,7 @@ class manipulator_builder {
     }
 
     /**
+     * execute_all
      * @throws coding_exception
      * @throws moodle_exception
      */
@@ -95,6 +100,7 @@ class manipulator_builder {
     }
 
     /**
+     * build
      * @param string $manipulator
      * @throws moodle_exception
      */

--- a/classes/local/object_manipulator/object_manipulator.php
+++ b/classes/local/object_manipulator/object_manipulator.php
@@ -31,12 +31,14 @@ interface object_manipulator {
 
 
     /**
+     * execute
      * @param array $objects
      * @return mixed
      */
     public function execute(array $objects);
 
     /**
+     * manipulate_object
      * @param stdClass $objectrecord
      * @return int
      */

--- a/classes/local/object_manipulator/orphaner.php
+++ b/classes/local/object_manipulator/orphaner.php
@@ -15,6 +15,8 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * Orphans records for files deleted
+ *
  * Orphans {tool_objectfs_objects} records for files that have been
  * deleted from the core {files} table.
  *
@@ -29,6 +31,9 @@ namespace tool_objectfs\local\object_manipulator;
 
 use stdClass;
 
+/**
+ * orphaner
+ */
 class orphaner extends manipulator {
 
     /**

--- a/classes/local/object_manipulator/puller.php
+++ b/classes/local/object_manipulator/puller.php
@@ -27,9 +27,13 @@ namespace tool_objectfs\local\object_manipulator;
 
 use stdClass;
 
+/**
+ * puller
+ */
 class puller extends manipulator {
 
     /**
+     * manipulate_object
      * @param stdClass $objectrecord
      * @return int
      */

--- a/classes/local/object_manipulator/pusher.php
+++ b/classes/local/object_manipulator/pusher.php
@@ -29,6 +29,9 @@ use stdClass;
 use tool_objectfs\local\store\object_file_system;
 use tool_objectfs\log\aggregate_logger;
 
+/**
+ * pusher
+ */
 class pusher extends manipulator {
 
     /**
@@ -59,6 +62,7 @@ class pusher extends manipulator {
     }
 
     /**
+     * manipulate_object
      * @param stdClass $objectrecord
      * @return int
      */

--- a/classes/local/object_manipulator/recoverer.php
+++ b/classes/local/object_manipulator/recoverer.php
@@ -27,9 +27,13 @@ namespace tool_objectfs\local\object_manipulator;
 
 use stdClass;
 
+/**
+ * recoverer
+ */
 class recoverer extends manipulator {
 
     /**
+     * manipulate_object
      * @param stdClass $objectrecord
      * @return int
      */

--- a/classes/local/report/location_report_builder.php
+++ b/classes/local/report/location_report_builder.php
@@ -47,7 +47,7 @@ class location_report_builder extends objectfs_report_builder {
             OBJECT_LOCATION_DUPLICATED,
             OBJECT_LOCATION_EXTERNAL,
             OBJECT_LOCATION_ORPHANED,
-            OBJECT_LOCATION_ERROR
+            OBJECT_LOCATION_ERROR,
         ];
 
         $totalcount = 0;
@@ -90,7 +90,7 @@ class location_report_builder extends objectfs_report_builder {
 
             if ($location !== OBJECT_LOCATION_ORPHANED) {
                 // Process the query normally.
-                $result = $DB->get_record_sql($sql, array($location));
+                $result = $DB->get_record_sql($sql, [$location]);
             } else if ($location === OBJECT_LOCATION_ORPHANED) {
                 // Start the query from objectfs, for ORPHANED objects, they are not located in the files table.
                 $sql =
@@ -101,7 +101,7 @@ class location_report_builder extends objectfs_report_builder {
                         WHERE o.location = ?)
                    SELECT COALESCE(COUNT(co.contenthash),0) AS objectcount
                      FROM cte_objects co';
-                $result = $DB->get_record_sql($sql, array($location));
+                $result = $DB->get_record_sql($sql, [$location]);
                 $result->objectsum = 0;
             }
 

--- a/classes/local/report/location_report_builder.php
+++ b/classes/local/report/location_report_builder.php
@@ -28,9 +28,14 @@ namespace tool_objectfs\local\report;
 use tool_objectfs\local\manager;
 use tool_objectfs\local\store\object_file_system;
 
+/**
+ * location_report_builder
+ */
 class location_report_builder extends objectfs_report_builder {
 
     /**
+     * build_report
+     * @param int $reportid
      * @return objectfs_report
      * @throws \dml_exception
      */

--- a/classes/local/report/log_size_report_builder.php
+++ b/classes/local/report/log_size_report_builder.php
@@ -25,8 +25,17 @@
 
 namespace tool_objectfs\local\report;
 
+/**
+ * log_size_report_builder
+ */
 class log_size_report_builder extends objectfs_report_builder {
 
+    /**
+     * build_report
+     * @param int $reportid
+     *
+     * @return objectfs_report
+     */
     public function build_report($reportid) {
         global $DB;
 
@@ -49,6 +58,12 @@ class log_size_report_builder extends objectfs_report_builder {
         return $report;
     }
 
+    /**
+     * compress_small_log_sizes
+     * @param mixed $stats
+     *
+     * @return void
+     */
     public function compress_small_log_sizes(&$stats) {
         $smallstats = new \stdClass();
         $smallstats->datakey = 1;

--- a/classes/local/report/mime_type_report_builder.php
+++ b/classes/local/report/mime_type_report_builder.php
@@ -25,8 +25,17 @@
 
 namespace tool_objectfs\local\report;
 
+/**
+ * mime_type_report_builder
+ */
 class mime_type_report_builder extends objectfs_report_builder {
 
+    /**
+     * build_report
+     * @param int $reportid
+     *
+     * @return objectfs_report
+     */
     public function build_report($reportid) {
         global $DB;
 

--- a/classes/local/report/object_location_history_table.php
+++ b/classes/local/report/object_location_history_table.php
@@ -82,7 +82,7 @@ class object_location_history_table extends \table_sql {
     public function query_db($pagesize, $useinitialsbar = true) {
         global $DB;
         $fields = 'CONCAT(reportid, datakey) AS uid, datakey AS location, objectcount AS count, objectsum AS size';
-        $conditions = array('reporttype' => 'location');
+        $conditions = ['reporttype' => 'location'];
         $rawrecords = $DB->get_records('tool_objectfs_report_data', $conditions, 'reportid', $fields);
         $reports = objectfs_report::get_report_ids();
 
@@ -90,7 +90,7 @@ class object_location_history_table extends \table_sql {
         // NOTE: This avoids the need to null coalesce on a non-existing count/size.
         $emptyrecord = (object)[
             'count' => 0,
-            'size' => 0
+            'size' => 0,
         ];
         foreach ($reports as $id => $timecreated) {
             // Initialises the records to be used, and fallback to an empty one if not found.

--- a/classes/local/report/object_status_history_table.php
+++ b/classes/local/report/object_status_history_table.php
@@ -102,7 +102,7 @@ class object_status_history_table extends \table_sql {
             default:
                 $sort = 'heading ASC';
         }
-        $params = array('reporttype' => $this->reporttype, 'reportid' => $this->reportid);
+        $params = ['reporttype' => $this->reporttype, 'reportid' => $this->reportid];
         $fields = 'datakey AS heading, objectcount AS count, objectsum AS size';
         $rows = $DB->get_records('tool_objectfs_report_data', $params, $sort, $fields);
         $this->rawdata = $rows;
@@ -196,7 +196,7 @@ class object_status_history_table extends \table_sql {
         if ($max > 0) {
             $share = round(100 * $value / $max, $precision);
         }
-        $htmlparams = array('class' => 'ofs-bar', 'style' => 'width:'.$share.'%');
+        $htmlparams = ['class' => 'ofs-bar', 'style' => 'width:'.$share.'%'];
 
         switch ($type) {
             case 'count':

--- a/classes/local/report/object_status_history_table.php
+++ b/classes/local/report/object_status_history_table.php
@@ -54,6 +54,9 @@ class object_status_history_table extends \table_sql {
 
     /**
      * Constructor for the file status history table.
+     *
+     * @param string $reporttype
+     * @param int $reportid
      */
     public function __construct($reporttype, $reportid) {
         parent::__construct('statushistory');

--- a/classes/local/report/objectfs_report.php
+++ b/classes/local/report/objectfs_report.php
@@ -25,19 +25,33 @@
 
 namespace tool_objectfs\local\report;
 
+/**
+ * objectfs_report
+ */
 class objectfs_report implements \renderable {
 
-    /** @var string $reporttype */
+    /**
+     * reporttype
+     * @var string
+     */
     protected $reporttype = '';
 
-    /** @var int $reportid */
+    /**
+     * reportid
+     * @var int
+     */
     protected $reportid = 0;
 
-    /** @var array $rows */
+    /**
+     * rows
+     * @var array
+     */
     protected $rows = [];
 
     /**
+     * construct
      * @param string $reporttype
+     * @param int $reportid
      */
     public function __construct($reporttype, $reportid) {
         $this->reporttype = $reporttype;
@@ -45,6 +59,7 @@ class objectfs_report implements \renderable {
     }
 
     /**
+     * add_row
      * @param string $datakey
      * @param int $objectcount
      * @param int $objectsum
@@ -58,6 +73,7 @@ class objectfs_report implements \renderable {
     }
 
     /**
+     * add_rows
      * @param array $rows
      */
     public function add_rows(array $rows) {
@@ -67,6 +83,7 @@ class objectfs_report implements \renderable {
     }
 
     /**
+     * get_rows
      * @return array
      */
     public function get_rows() {
@@ -74,6 +91,7 @@ class objectfs_report implements \renderable {
     }
 
     /**
+     * get_report_type
      * @return string
      */
     public function get_report_type() {
@@ -81,6 +99,7 @@ class objectfs_report implements \renderable {
     }
 
     /**
+     * get_report_id
      * @return int
      */
     public function get_report_id() {
@@ -105,6 +124,10 @@ class objectfs_report implements \renderable {
         }
     }
 
+    /**
+     * generate_status_report
+     * @return void
+     */
     public static function generate_status_report() {
         global $DB;
         $reportid = $DB->insert_record('tool_objectfs_reports', (object)['reportdate' => time()]);
@@ -135,6 +158,7 @@ class objectfs_report implements \renderable {
     }
 
     /**
+     * get_report_types
      * @return array
      */
     public static function get_report_types() {

--- a/classes/local/report/objectfs_report.php
+++ b/classes/local/report/objectfs_report.php
@@ -150,7 +150,7 @@ class objectfs_report implements \renderable {
     public static function cleanup_reports() {
         global $DB;
         $reportdate = time() - YEARSECS;
-        $params = array('reportdate' => $reportdate);
+        $params = ['reportdate' => $reportdate];
         $reports = $DB->get_records_select('tool_objectfs_reports', 'reportdate < :reportdate', $params, 'id', 'id');
         $reportids = array_keys($reports);
         $DB->delete_records_list('tool_objectfs_reports', 'id', $reportids);
@@ -177,7 +177,7 @@ class objectfs_report implements \renderable {
      */
     public static function get_report_ids() {
         global $DB;
-        $reports = array();
+        $reports = [];
         $records = $DB->get_records('tool_objectfs_reports', null, 'id DESC', 'id, reportdate');
         foreach ($records as $record) {
             $reports[$record->id] = $record->reportdate;

--- a/classes/local/report/objectfs_report_builder.php
+++ b/classes/local/report/objectfs_report_builder.php
@@ -25,7 +25,16 @@
 
 namespace tool_objectfs\local\report;
 
+/**
+ * objectfs_report_builder
+ */
 abstract class objectfs_report_builder {
 
+    /**
+     * build_report
+     * @param int $reportid
+     *
+     * @return objectfs_report
+     */
     abstract public function build_report($reportid);
 }

--- a/classes/local/store/azure/client.php
+++ b/classes/local/store/azure/client.php
@@ -149,11 +149,11 @@ class client extends object_client_base {
      * @return resource
      */
     public function get_seekable_stream_context() {
-        $context = stream_context_create(array(
-            'blob' => array(
-                'seekable' => true
-            )
-        ));
+        $context = stream_context_create([
+            'blob' => [
+                'seekable' => true,
+            ],
+        ]);
         return $context;
     }
 
@@ -259,7 +259,7 @@ class client extends object_client_base {
     public function test_permissions($testdelete) {
         $permissions = new \stdClass();
         $permissions->success = true;
-        $permissions->messages = array();
+        $permissions->messages = [];
 
         try {
             $result = $this->client->createBlockBlob($this->container, 'permissions_check_file', 'permissions_check_file');

--- a/classes/local/store/azure/client.php
+++ b/classes/local/store/azure/client.php
@@ -30,6 +30,9 @@ use stdClass;
 use tool_objectfs\local\store\azure\stream_wrapper;
 use tool_objectfs\local\store\object_client_base;
 
+/**
+ * client
+ */
 class client extends object_client_base {
 
     /** @var BlobRestProxy $client The Blob client. */
@@ -41,7 +44,7 @@ class client extends object_client_base {
     /**
      * The azure client constructor.
      *
-     * @param $config
+     * @param \stdclass $config
      */
     public function __construct($config) {
         global $CFG;
@@ -141,6 +144,10 @@ class client extends object_client_base {
         return $relativepath;
     }
 
+    /**
+     * get_seekable_stream_context
+     * @return resource
+     */
     public function get_seekable_stream_context() {
         $context = stream_context_create(array(
             'blob' => array(
@@ -153,7 +160,7 @@ class client extends object_client_base {
     /**
      * Trim a leading '?' character from the sas token.
      *
-     * @param $sastoken
+     * @param string $sastoken
      * @return bool|string
      */
     private function clean_sastoken($sastoken) {
@@ -164,6 +171,12 @@ class client extends object_client_base {
         return $sastoken;
     }
 
+    /**
+     * get_md5_from_hash
+     * @param string $contenthash
+     *
+     * @return string
+     */
     private function get_md5_from_hash($contenthash) {
         try {
             $key = $this->get_filepath_from_hash($contenthash);
@@ -185,6 +198,13 @@ class client extends object_client_base {
         return $md5;
     }
 
+    /**
+     * verify_objectverify_object
+     * @param string $contenthash
+     * @param string $localpath
+     *
+     * @return bool
+     */
     public function verify_object($contenthash, $localpath) {
         // For objects uploaded to S3 storage using the multipart upload, the etag will not be the objects MD5.
         // So we can't compare here to verify the object.
@@ -196,12 +216,22 @@ class client extends object_client_base {
         return false;
     }
 
+    /**
+     * get_filepath_from_hash
+     * @param string $contenthash
+     *
+     * @return string
+     */
     protected function get_filepath_from_hash($contenthash) {
         $l1 = $contenthash[0] . $contenthash[1];
         $l2 = $contenthash[2] . $contenthash[3];
         return "$l1/$l2/$contenthash";
     }
 
+    /**
+     * test_connection
+     * @return stdClass
+     */
     public function test_connection() {
         $connection = new \stdClass();
         $connection->success = true;
@@ -220,6 +250,12 @@ class client extends object_client_base {
         return $connection;
     }
 
+    /**
+     * test_permissions
+     * @param mixed $testdelete
+     *
+     * @return stdClass
+     */
     public function test_permissions($testdelete) {
         $permissions = new \stdClass();
         $permissions->success = true;
@@ -268,6 +304,12 @@ class client extends object_client_base {
         return $permissions;
     }
 
+    /**
+     * get_exception_details
+     * @param \MicrosoftAzure\Storage\Common\Exceptions\ServiceException $exception
+     *
+     * @return string
+     */
     protected function get_exception_details(\MicrosoftAzure\Storage\Common\Exceptions\ServiceException $exception) {
         $message = $exception->getErrorMessage();
 
@@ -298,7 +340,7 @@ class client extends object_client_base {
      * Shared Access Signature.
      *
      * @param admin_settingpage $settings
-     * @param $config
+     * @param  \stdClass $config
      * @return admin_settingpage
      */
     public function define_client_section($settings, $config) {

--- a/classes/local/store/azure/file_system.php
+++ b/classes/local/store/azure/file_system.php
@@ -31,8 +31,17 @@ use tool_objectfs\local\store\object_file_system;
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * file_system
+ */
 class file_system extends object_file_system {
 
+    /**
+     * initialise_external_client
+     * @param mixed $config
+     *
+     * @return client
+     */
     protected function initialise_external_client($config) {
         $asclient = new client($config);
         return $asclient;

--- a/classes/local/store/azure/stream_wrapper.php
+++ b/classes/local/store/azure/stream_wrapper.php
@@ -42,6 +42,9 @@ use MicrosoftAzure\Storage\Blob\Models\SetBlobPropertiesOptions;
 use MicrosoftAzure\Storage\Common\Exceptions\ServiceException;
 use Psr\Http\Message\StreamInterface;
 
+/**
+ * stream_wrapper
+ */
 class stream_wrapper {
 
     /** @var resource|null Stream context (this is set by PHP) */
@@ -85,16 +88,35 @@ class stream_wrapper {
         stream_context_set_default($default);
     }
 
-    public function stream_cast($cast_as) {
+    /**
+     * stream_cast
+     * @param mixed $cast_as
+     *
+     * @return boolean
+     */
+    public function stream_cast($castas) {
         return false;
     }
 
+    /**
+     * stream_close
+     * @return void
+     */
     public function stream_close() {
         $this->body = null;
         $this->hash = null;
     }
 
-    public function stream_open($path, $mode, $options, &$opened_path) {
+    /**
+     * stream_open
+     * @param mixed $path
+     * @param mixed $mode
+     * @param mixed $options
+     * @param mixed $opened_path
+     *
+     * @return bool
+     */
+    public function stream_open($path, $mode, $options, &$openedpath) {
         $this->initProtocol($path);
         $this->params = $this->getContainerKey($path);
         $this->mode = rtrim($mode, 'bt');
@@ -107,17 +129,28 @@ class stream_wrapper {
 
         return $this->boolCall(function() use ($path) {
             switch ($this->mode) {
-                case 'r': return $this->openReadStream();
-                case 'a': return $this->openAppendStream();
-                default: return $this->openWriteStream();
+                case 'r':
+return $this->openReadStream();
+                case 'a':
+return $this->openAppendStream();
+                default:
+return $this->openWriteStream();
             }
         });
     }
 
+    /**
+     * stream_eof
+     * @return bool
+     */
     public function stream_eof() {
         return $this->body->eof();
     }
 
+    /**
+     * stream_flush
+     * @return bool
+     */
     public function stream_flush() {
         if ($this->mode == 'r') {
             return false;
@@ -153,11 +186,24 @@ class stream_wrapper {
         });
     }
 
+    /**
+     * stream_read
+     * @param int $count
+     *
+     * @return string
+     */
     public function stream_read($count) {
         // If the file isn't readable, we need to return no content. Azure can emit XML here otherwise.
         return $this->readable ? $this->body->read($count) : '';
     }
 
+    /**
+     * stream_seek
+     * @param int $offset
+     * @param int $whence
+     *
+     * @return bool
+     */
     public function stream_seek($offset, $whence = SEEK_SET) {
         return !$this->body->isSeekable()
             ? false
@@ -167,15 +213,30 @@ class stream_wrapper {
             });
     }
 
+    /**
+     * stream_tell
+     * @return bool
+     */
     public function stream_tell() {
-        return $this->boolCall(function() { return $this->body->tell(); });
+        return $this->boolCall(function() { return $this->body->tell();
+        });
     }
 
+    /**
+     * stream_write
+     * @param string $data
+     *
+     * @return int
+     */
     public function stream_write($data) {
         hash_update($this->hash, $data);
         return $this->body->write($data);
     }
 
+    /**
+     * stream_stat
+     * @return array
+     */
     public function stream_stat() {
         $stat = $this->getStatTemplate();
         $stat[7] = $stat['size'] = $this->getSize();
@@ -185,9 +246,16 @@ class stream_wrapper {
     }
 
     /**
+     * url_stat
+     *
      * Provides information for is_dir, is_file, filesize, etc. Works on
      * buckets, keys, and prefixes.
      * @link http://www.php.net/manual/en/streamwrapper.url-stat.php
+     *
+     * @param string $path
+     * @param mixed $flags
+     *
+     * @return mixed
      */
     public function url_stat($path, $flags) {
         $stat = $this->getStatTemplate();
@@ -219,17 +287,23 @@ class stream_wrapper {
     /**
      * Parse the protocol out of the given path.
      *
-     * @param $path
+     * @param string $path
      */
-    private function initProtocol($path) {
+    private function initprotocol($path) {
         $parts = explode('://', $path, 2);
         $this->protocol = $parts[0] ?: 'blob';
     }
 
-    private function getContainerKey($path) {
-        // Remove the protocol
+    /**
+     * getContainerKey
+     * @param string $path
+     *
+     * @return array
+     */
+    private function getcontainerkey($path) {
+        // Remove the protocol.
         $parts = explode('://', $path);
-        // Get the container, key
+        // Get the container, key.
         $parts = explode('/', $parts[1], 2);
 
         return [
@@ -241,6 +315,14 @@ class stream_wrapper {
     /**
      * Validates the provided stream arguments for fopen and returns an array
      * of errors.
+     */
+    /**
+     * Validates the provided stream arguments for fopen and returns an array
+     * of errors.
+     * @param string $path
+     * @param string $mode
+     *
+     * @return [type]
      */
     private function validate($path, $mode) {
         $errors = [];
@@ -255,8 +337,7 @@ class stream_wrapper {
                 . "Use one 'r', 'w', 'a', or 'x'.";
         }
 
-        // When using mode "x" validate if the file exists before attempting
-        // to read
+        // When using mode "x" validate if the file exists before attempting to read.
         if ($mode == 'x' &&
             $this->getClient()->getBlobProperties(
                 $this->getOption('Container'),
@@ -288,8 +369,8 @@ class stream_wrapper {
      *
      * @return array
      */
-    private function getOptions($removeContextData = false) {
-        // Context is not set when doing things like stat
+    private function getoptions($removecontextdata = false) {
+        // Context is not set when doing things like stat.
         if ($this->context === null) {
             $options = [];
         } else {
@@ -305,7 +386,7 @@ class stream_wrapper {
             : [];
         $result = $this->params + $options + $default;
 
-        if ($removeContextData) {
+        if ($removecontextdata) {
             unset($result['client'], $result['seekable']);
         }
 
@@ -319,7 +400,7 @@ class stream_wrapper {
      *
      * @return mixed|null
      */
-    private function getOption($name) {
+    private function getoption($name) {
         $options = $this->getOptions();
 
         return isset($options[$name]) ? $options[$name] : null;
@@ -331,7 +412,7 @@ class stream_wrapper {
      * @return BlobRestProxy
      * @throws \RuntimeException if no client has been configured
      */
-    private function getClient() {
+    private function getclient() {
         if (!$client = $this->getOption('client')) {
             throw new \RuntimeException('No client in stream context');
         }
@@ -346,13 +427,17 @@ class stream_wrapper {
      *
      * @return array Hash of 'Container', 'Key', and custom params from the context
      */
-    private function withPath($path) {
+    private function withpath($path) {
         $params = $this->getOptions(true);
 
         return $this->getContainerKey($path) + $params;
     }
 
-    private function openReadStream() {
+    /**
+     * openReadStream
+     * @return bool
+     */
+    private function openreadstream() {
         $client = $this->getClient();
         $params = $this->getOptions(true);
 
@@ -365,7 +450,7 @@ class stream_wrapper {
             $this->body = $response->getBody();
         }
 
-        // Wrap the body in a caching entity body if seeking is allowed
+        // Wrap the body in a caching entity body if seeking is allowed.
         if ($this->getOption('seekable') && !$this->body->isSeekable()) {
             $this->body = new CachingStream($this->body);
         }
@@ -373,21 +458,29 @@ class stream_wrapper {
         return true;
     }
 
-    private function openWriteStream() {
+    /**
+     * openWriteStream
+     * @return bool
+     */
+    private function openwritestream() {
         $this->body = new Stream(fopen('php://temp', 'r+'));
         return true;
     }
 
-    private function openAppendStream() {
+    /**
+     * openAppendStream
+     * @return mixed
+     */
+    private function openappendstream() {
         try {
-            // Get the body of the object and seek to the end of the stream
+            // Get the body of the object and seek to the end of the stream.
             $client = $this->getClient();
             $params = $this->getOptions(true);
             $this->body = $client->getBlob($params['Container'], $params['Key']);
             $this->body->seek(0, SEEK_END);
             return true;
         } catch (ServiceException $e) {
-            // The object does not exist, so use a simple write stream
+            // The object does not exist, so use a simple write stream.
             return $this->openWriteStream();
         }
     }
@@ -397,7 +490,7 @@ class stream_wrapper {
      *
      * @return array
      */
-    private function getStatTemplate() {
+    private function getstattemplate() {
         return [
             0  => 0,  'dev'     => 0,
             1  => 0,  'ino'     => 0,
@@ -424,7 +517,7 @@ class stream_wrapper {
      *
      * @return bool
      */
-    private function boolCall(callable $fn, $flags = null) {
+    private function boolcall(callable $fn, $flags = null) {
         try {
             return $fn();
         } catch (\Exception $e) {
@@ -442,16 +535,16 @@ class stream_wrapper {
      * @return bool Returns false
      * @throws \RuntimeException if throw_errors is true
      */
-    private function triggerError($errors, $flags = null) {
-        // This is triggered with things like file_exists()
+    private function triggererror($errors, $flags = null) {
+        // This is triggered with things like file_exists().
         if ($flags & STREAM_URL_STAT_QUIET) {
             return $flags & STREAM_URL_STAT_LINK
-                // This is triggered for things like is_link()
+                // This is triggered for things like is_link().
                 ? $this->getStatTemplate()
                 : false;
         }
 
-        // This is triggered when doing things like lstat() or stat()
+        // This is triggered when doing things like lstat() or stat().
         trigger_error(implode("\n", (array) $errors), E_USER_WARNING);
 
         return false;
@@ -462,7 +555,7 @@ class stream_wrapper {
      *
      * @return int|null
      */
-    private function getSize() {
+    private function getsize() {
         $size = $this->body->getSize();
 
         return $size !== null ? $size : $this->size;

--- a/classes/local/store/digitalocean/client.php
+++ b/classes/local/store/digitalocean/client.php
@@ -19,6 +19,7 @@
  *
  * @package   tool_objectfs
  * @author    Brian Yanosik <kisonay@gmail.com>
+ * @copyright Brian Yanosik
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -26,8 +27,16 @@ namespace tool_objectfs\local\store\digitalocean;
 
 use tool_objectfs\local\store\s3\client as s3_client;
 
+/**
+ * client
+ */
 class client extends s3_client {
 
+    /**
+     * construct
+     * @param \stdClass $config
+     * @return void
+     */
     public function __construct($config) {
         global $CFG;
         $this->autoloader = $CFG->dirroot . '/local/aws/sdk/aws-autoloader.php';
@@ -56,6 +65,12 @@ class client extends s3_client {
         return true;
     }
 
+    /**
+     * set_client
+     * @param \stdClass $config
+     *
+     * @return void
+     */
     public function set_client($config) {
         if (!$this->is_configured($config)) {
             $this->client = null;
@@ -71,8 +86,9 @@ class client extends s3_client {
     }
 
     /**
+     * define_client_section
      * @param admin_settingpage $settings
-     * @param $config
+     * @param \stdClass $config
      * @return admin_settingpage
      */
     public function define_client_section($settings, $config) {

--- a/classes/local/store/digitalocean/client.php
+++ b/classes/local/store/digitalocean/client.php
@@ -77,12 +77,12 @@ class client extends s3_client {
             return;
         }
 
-        $this->client = \Aws\S3\S3Client::factory(array(
-            'credentials' => array('key' => $config->do_key, 'secret' => $config->do_secret),
+        $this->client = \Aws\S3\S3Client::factory([
+            'credentials' => ['key' => $config->do_key, 'secret' => $config->do_secret],
             'region' => $config->do_region,
             'endpoint' => 'https://' . $config->do_region . '.digitaloceanspaces.com',
-            'version' => AWS_API_VERSION
-        ));
+            'version' => AWS_API_VERSION,
+        ]);
     }
 
     /**
@@ -93,13 +93,13 @@ class client extends s3_client {
      */
     public function define_client_section($settings, $config) {
 
-        $regionoptions = array(
+        $regionoptions = [
             'sfo2'      => 'sfo2 (San Fransisco)',
             'nyc3'      => 'nyc3 (New York City)',
             'ams3'      => 'ams3 (Amsterdam)',
             'sgp1'      => 'spg1 (Singapore)',
             'fra1'      => 'fra1 (Frankfurt)',
-        );
+        ];
 
         $settings->add(new \admin_setting_heading('tool_objectfs/do',
             new \lang_string('settings:do:header', 'tool_objectfs'), ''));

--- a/classes/local/store/digitalocean/file_system.php
+++ b/classes/local/store/digitalocean/file_system.php
@@ -22,6 +22,7 @@
  *
  * @package   tool_objectfs
  * @author    Brian Yanosik <kisonay@gmail.com>
+ * @copyright Brian Yanosik
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -33,8 +34,17 @@ use tool_objectfs\local\store\s3\file_system as s3_file_system;
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * [Description file_system]
+ */
 class file_system extends s3_file_system {
 
+    /**
+     * initialise_external_client
+     * @param \stdClass $config
+     *
+     * @return client
+     */
     protected function initialise_external_client($config) {
         $doclient = new client($config);
 

--- a/classes/local/store/object_client.php
+++ b/classes/local/store/object_client.php
@@ -98,7 +98,7 @@ interface object_client {
      *
      * @return mixed
      */
-    public function generate_presigned_url($contenthash, $headers = array());
+    public function generate_presigned_url($contenthash, $headers = []);
 
     /**
      * support_presigned_urls

--- a/classes/local/store/object_client.php
+++ b/classes/local/store/object_client.php
@@ -26,21 +26,117 @@
 namespace tool_objectfs\local\store;
 
 interface object_client {
+
+    /**
+     * construct
+     * @param \stdClass $config
+     */
     public function __construct($config);
+
+    /**
+     * register_stream_wrapper
+     * @return mixed
+     */
     public function register_stream_wrapper();
+
+    /**
+     * get_fullpath_from_hash
+     * @param string $contenthash
+     *
+     * @return string
+     */
     public function get_fullpath_from_hash($contenthash);
+
+    /**
+     * delete_file
+     * @param string $fullpath
+     *
+     * @return mixed
+     */
     public function delete_file($fullpath);
+
+    /**
+     * rename_file
+     * @param string $currentpath
+     * @param string $destinationpath
+     *
+     * @return mixed
+     */
     public function rename_file($currentpath, $destinationpath);
+
+    /**
+     * get_seekable_stream_context
+     * @return mixed
+     */
     public function get_seekable_stream_context();
+
+    /**
+     * get_availability
+     * @return mixed
+     */
     public function get_availability();
+
+    /**
+     * get_maximum_upload_size
+     * @return mixed
+     */
     public function get_maximum_upload_size();
+
+    /**
+     * verify_object
+     * @param string $contenthash
+     * @param string $localpath
+     *
+     * @return mixed
+     */
     public function verify_object($contenthash, $localpath);
+
+    /**
+     * generate_presigned_url
+     * @param string $contenthash
+     * @param array $headers
+     *
+     * @return mixed
+     */
     public function generate_presigned_url($contenthash, $headers = array());
+
+    /**
+     * support_presigned_urls
+     * @return mixed
+     */
     public function support_presigned_urls();
+
+    /**
+     * test_connection
+     * @return mixed
+     */
     public function test_connection();
+
+    /**
+     * test_permissions
+     * @param mixed $testdelete
+     *
+     * @return mixed
+     */
     public function test_permissions($testdelete);
+
+    /**
+     * proxy_range_request
+     * @param \stored_file $file
+     * @param mixed $ranges
+     *
+     * @return mixed
+     */
     public function proxy_range_request(\stored_file $file, $ranges);
+
+    /**
+     * test_range_request
+     * @param mixed $filesystem
+     *
+     * @return mixed
+     */
     public function test_range_request($filesystem);
+
 }
 
 

--- a/classes/local/store/object_client_base.php
+++ b/classes/local/store/object_client_base.php
@@ -103,7 +103,7 @@ abstract class object_client_base implements object_client {
      *
      * @throws \coding_exception
      */
-    public function generate_presigned_url($contenthash, $headers = array()) {
+    public function generate_presigned_url($contenthash, $headers = []) {
         throw new \coding_exception("Pre-signed URLs not supported");
     }
 

--- a/classes/local/store/object_client_base.php
+++ b/classes/local/store/object_client_base.php
@@ -25,12 +25,30 @@
 
 namespace tool_objectfs\local\store;
 
+/**
+ * [Description object_client_base]
+ */
 abstract class object_client_base implements object_client {
 
+    /**
+     * @var string
+     */
     protected $autoloader;
+    /**
+     * @var mixed
+     */
     protected $expirationtime;
+    /**
+     * @var bool
+     */
     protected $testdelete = true;
+    /**
+     * @var int
+     */
     public $presignedminfilesize;
+    /**
+     * @var mixed
+     */
     public $enablepresignedurls;
 
     /** @var int $maxupload Maximum allowed file size that can be uploaded. */
@@ -39,6 +57,10 @@ abstract class object_client_base implements object_client {
     /** @var object $config Client config. */
     protected $config;
 
+    /**
+     * construct
+     * @param \stdClass $config
+     */
     public function __construct($config) {
 
     }
@@ -56,6 +78,10 @@ abstract class object_client_base implements object_client {
         }
     }
 
+    /**
+     * register_stream_wrapper
+     * @return void
+     */
     public function register_stream_wrapper() {
 
     }

--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -45,13 +45,32 @@ require_once($CFG->libdir . '/filestorage/file_system.php');
 require_once($CFG->libdir . '/filestorage/file_system_filedir.php');
 require_once($CFG->libdir . '/filestorage/file_storage.php');
 
+/**
+ * [Description object_file_system]
+ */
 abstract class object_file_system extends \file_system_filedir {
 
+    /**
+     * @var mixed
+     */
     public $externalclient;
+    /**
+     * @var mixed
+     */
     private $preferexternal;
+    /**
+     * @var mixed
+     */
     private $deleteexternally;
+    /**
+     * @var mixed
+     */
     private $logger;
 
+    /**
+     * construct
+     * @return void
+     */
     public function __construct() {
         global $CFG;
         parent::__construct(); // Setup filedir.
@@ -72,6 +91,12 @@ abstract class object_file_system extends \file_system_filedir {
         }
     }
 
+    /**
+     * set_logger
+     * @param \tool_objectfs\log\objectfs_logger $logger
+     *
+     * @return void
+     */
     public function set_logger(\tool_objectfs\log\objectfs_logger $logger) {
         $this->logger = $logger;
     }
@@ -94,6 +119,12 @@ abstract class object_file_system extends \file_system_filedir {
         return $this->externalclient;
     }
 
+    /**
+     * initialise_external_client
+     * @param mixed $config
+     *
+     * @return mixed
+     */
     abstract protected function initialise_external_client($config);
 
     /**
@@ -133,10 +164,22 @@ abstract class object_file_system extends \file_system_filedir {
         return $path;
     }
 
+    /**
+     * get_remote_path_from_storedfile
+     * @param \stored_file $file
+     *
+     * @return string
+     */
     public function get_remote_path_from_storedfile(\stored_file $file) {
         return $this->get_remote_path_from_hash($file->get_contenthash());
     }
 
+    /**
+     * get_remote_path_from_hash
+     * @param mixed $contenthash
+     *
+     * @return string
+     */
     protected function get_remote_path_from_hash($contenthash) {
         if ($this->preferexternal) {
             $location = $this->get_object_location_from_hash($contenthash);
@@ -155,14 +198,32 @@ abstract class object_file_system extends \file_system_filedir {
         return $path;
     }
 
+    /**
+     * get_external_path_from_hash
+     * @param mixed $contenthash
+     *
+     * @return string
+     */
     protected function get_external_path_from_hash($contenthash) {
         return $this->externalclient->get_fullpath_from_hash($contenthash);
     }
 
+    /**
+     * get_external_path_from_storedfile
+     * @param \stored_file $file
+     *
+     * @return string
+     */
     protected function get_external_path_from_storedfile(\stored_file $file) {
         return $this->get_external_path_from_hash($file->get_contenthash());
     }
 
+    /**
+     * is_file_readable_externally_by_storedfile
+     * @param stored_file $file
+     *
+     * @return bool
+     */
     public function is_file_readable_externally_by_storedfile(stored_file $file) {
         if (!$file->get_filesize()) {
             // Files with empty size are either directories or empty.
@@ -178,6 +239,12 @@ abstract class object_file_system extends \file_system_filedir {
         return false;
     }
 
+    /**
+     * is_file_readable_externally_by_hash
+     * @param mixed $contenthash
+     *
+     * @return bool
+     */
     public function is_file_readable_externally_by_hash($contenthash) {
         if ($contenthash === sha1('')) {
             // Files with empty size are either directories or empty.
@@ -191,6 +258,12 @@ abstract class object_file_system extends \file_system_filedir {
         return is_readable($path);
     }
 
+    /**
+     * get_object_location_from_hash
+     * @param mixed $contenthash
+     *
+     * @return int
+     */
     public function get_object_location_from_hash($contenthash) {
         $localreadable = $this->is_file_readable_locally_by_hash($contenthash);
         $externalreadable = $this->is_file_readable_externally_by_hash($contenthash);
@@ -208,7 +281,13 @@ abstract class object_file_system extends \file_system_filedir {
         }
     }
 
-    // Acquire the object lock any time you are moving an object between locations.
+    /**
+     * Acquire the object lock any time you are moving an object between locations.
+     * @param mixed $contenthash
+     * @param int $timeout
+     *
+     * @return \core\lock\lock|boolean
+     */
     public function acquire_object_lock($contenthash, $timeout = 0) {
         $resource = "tool_objectfs: $contenthash";
         $lockfactory = \core\lock\lock_config::get_lock_factory('tool_objectfs_object');
@@ -220,6 +299,13 @@ abstract class object_file_system extends \file_system_filedir {
         return $lock;
     }
 
+    /**
+     * copy_object_from_external_to_local_by_hash
+     * @param mixed $contenthash
+     * @param int $objectsize
+     *
+     * @return int
+     */
     public function copy_object_from_external_to_local_by_hash($contenthash, $objectsize = 0) {
         $initiallocation = $this->get_object_location_from_hash($contenthash);
         $finallocation = $initiallocation;
@@ -253,6 +339,13 @@ abstract class object_file_system extends \file_system_filedir {
         return $finallocation;
     }
 
+    /**
+     * copy_object_from_local_to_external_by_hash
+     * @param mixed $contenthash
+     * @param int $objectsize
+     *
+     * @return int
+     */
     public function copy_object_from_local_to_external_by_hash($contenthash, $objectsize = 0) {
         $initiallocation = $this->get_object_location_from_hash($contenthash);
 
@@ -275,12 +368,25 @@ abstract class object_file_system extends \file_system_filedir {
         return $finallocation;
     }
 
+    /**
+     * verify_external_object_from_hash
+     * @param mixed $contenthash
+     *
+     * @return mixed
+     */
     public function verify_external_object_from_hash($contenthash) {
         $localpath = $this->get_local_path_from_hash($contenthash);
         $objectisvalid = $this->externalclient->verify_object($contenthash, $localpath);
         return $objectisvalid;
     }
 
+    /**
+     * delete_object_from_local_by_hash
+     * @param mixed $contenthash
+     * @param int $objectsize
+     *
+     * @return int
+     */
     public function delete_object_from_local_by_hash($contenthash, $objectsize = 0) {
         $initiallocation = $this->get_object_location_from_hash($contenthash);
         $finallocation = $initiallocation;
@@ -622,6 +728,9 @@ abstract class object_file_system extends \file_system_filedir {
      * Deletes external file depending on deleteexternal settings.
      *
      * @param string $contenthash file to be moved
+     * @param bool $force
+     *
+     * @return void
      */
     public function delete_external_file_from_hash($contenthash, $force = false) {
         if ($force || (!empty($this->deleteexternally) && $this->deleteexternally == TOOL_OBJECTFS_DELETE_EXTERNAL_FULL)) {
@@ -692,7 +801,7 @@ abstract class object_file_system extends \file_system_filedir {
     /**
      * Delete file with external client.
      *
-     * @path   path to file to be deleted.
+     * @param string $path   path to file to be deleted.
      * @return bool.
      */
     public function delete_client_file($path) {
@@ -784,6 +893,10 @@ abstract class object_file_system extends \file_system_filedir {
         return false;
     }
 
+    /**
+     * presigned_url_configured
+     * @return mixed
+     */
     public function presigned_url_configured() {
         return $this->externalclient->support_presigned_urls()
             && $this->externalclient->enablepresignedurls;
@@ -877,6 +990,7 @@ abstract class object_file_system extends \file_system_filedir {
     }
 
     /**
+     * exec_command
      * @param string $command
      * @return int
      */
@@ -1024,8 +1138,8 @@ abstract class object_file_system extends \file_system_filedir {
     /**
      * Update file remote location.
      *
-     * @param array (contenthash, filesize, newfile)
-     * @return array (contenthash, filesize, newfile)
+     * @param array $result [contenthash, filesize, newfile]
+     * @return array [contenthash, filesize, newfile]
      */
     private function update_object(array $result): array {
         // Rather than getting its exact location we just set it to local.

--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -470,7 +470,7 @@ abstract class object_file_system extends \file_system_filedir {
                             $pathinfo['filename'],
                             $pathinfo['basename'],
                             $pathinfo['filename'],
-                            $pathinfo['basename']
+                            $pathinfo['basename'],
                         ]);
 
                         if (!$exists) {
@@ -844,7 +844,7 @@ abstract class object_file_system extends \file_system_filedir {
      * @return bool
      * @throws \dml_exception
      */
-    public function redirect_to_presigned_url($contenthash, $headers = array()) {
+    public function redirect_to_presigned_url($contenthash, $headers = []) {
         global $FULLME;
         try {
             $signedurl = $this->externalclient->generate_presigned_url($contenthash, $headers);
@@ -926,7 +926,7 @@ abstract class object_file_system extends \file_system_filedir {
      * @return bool
      * @throws \dml_exception
      */
-    public function presigned_url_should_redirect($contenthash, $headers = array()) {
+    public function presigned_url_should_redirect($contenthash, $headers = []) {
         // Redirect regardless.
         if ($this->externalclient->presignedminfilesize == 0 &&
                 manager::all_extensions_whitelisted()) {

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -670,7 +670,13 @@ class client extends object_client_base {
 
             if (!empty($originalfilename)) {
                 $result['Content-Disposition'] = $contentdisposition;
-                $result['filename'] = 'filename="' . utf8_encode($originalfilename) . '"';
+                // The filename parameter must be in ISO-8859-1, however it works in browsers if
+                // you treat the original UTF-8 string as ISO-8859-1 characters. To achieve that
+                // here, we encode the UTF-8 as if it were ISO-8859-1. This behaviour is hideous
+                // so it would be nice to use the optional filename* field (RFC 5987) but S3 still
+                // complains if we do that.
+                $jankyfilename = \core_text::convert($originalfilename, 'ISO-8859-1');
+                $result['filename'] = 'filename="' . $jankyfilename . '"';
                 $result['Content-Type'] = $originalcontenttype;
             }
         }

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -94,7 +94,7 @@ class client extends object_client_base {
      * @return array
      */
     public function __sleep() {
-        return array('bucket');
+        return ['bucket'];
     }
 
     /**
@@ -153,17 +153,17 @@ class client extends object_client_base {
             return;
         }
 
-        $options = array(
+        $options = [
             'region' => $config->s3_region,
-            'version' => AWS_API_VERSION
-        );
+            'version' => AWS_API_VERSION,
+        ];
 
         if (empty($config->s3_usesdkcreds)) {
-            $options['credentials'] = array('key' => $config->s3_key, 'secret' => $config->s3_secret);
+            $options['credentials'] = ['key' => $config->s3_key, 'secret' => $config->s3_secret];
         }
 
         if ($config->useproxy) {
-            $options['http'] = array('proxy' => $this->get_proxy_string());
+            $options['http'] = ['proxy' => $this->get_proxy_string()];
         }
 
         // Support base_url config for aws api compatible endpoints.
@@ -199,9 +199,9 @@ class client extends object_client_base {
 
         try {
             $key = $this->get_filepath_from_hash($contenthash);
-            $result = $this->client->headObject(array(
+            $result = $this->client->headObject([
                             'Bucket' => $this->bucket,
-                            'Key' => $this->bucketkeyprefix . $key));
+                            'Key' => $this->bucketkeyprefix . $key]);
         } catch (\Aws\S3\Exception\S3Exception $e) {
             return false;
         }
@@ -268,11 +268,11 @@ class client extends object_client_base {
      * @return mixed
      */
     public function get_seekable_stream_context() {
-        $context = stream_context_create(array(
-            's3' => array(
-                'seekable' => true
-            )
-        ));
+        $context = stream_context_create([
+            's3' => [
+                'seekable' => true,
+            ],
+        ]);
         return $context;
     }
 
@@ -306,7 +306,7 @@ class client extends object_client_base {
                 $connection->success = false;
                 $connection->details = get_string('settings:notconfigured', 'tool_objectfs');
             } else {
-                $this->client->headBucket(array('Bucket' => $this->bucket));
+                $this->client->headBucket(['Bucket' => $this->bucket]);
             }
         } catch (\Aws\S3\Exception\S3Exception $e) {
             $connection->success = false;
@@ -334,19 +334,19 @@ class client extends object_client_base {
     public function test_permissions($testdelete) {
         $permissions = new \stdClass();
         $permissions->success = true;
-        $permissions->messages = array();
+        $permissions->messages = [];
 
         if ($this->is_functional()) {
             $permissions->success = false;
-            $permissions->messages = array();
+            $permissions->messages = [];
             return $permissions;
         }
 
         try {
-            $result = $this->client->putObject(array(
+            $result = $this->client->putObject([
                 'Bucket' => $this->bucket,
                 'Key' => $this->bucketkeyprefix . 'permissions_check_file',
-                'Body' => 'test content'));
+                'Body' => 'test content']);
         } catch (\Aws\S3\Exception\S3Exception $e) {
             $details = $this->get_exception_details($e);
             $permissions->messages[get_string('settings:writefailure', 'tool_objectfs') . $details] = 'notifyproblem';
@@ -354,9 +354,9 @@ class client extends object_client_base {
         }
 
         try {
-            $result = $this->client->getObject(array(
+            $result = $this->client->getObject([
                 'Bucket' => $this->bucket,
-                'Key' => $this->bucketkeyprefix . 'permissions_check_file'));
+                'Key' => $this->bucketkeyprefix . 'permissions_check_file']);
         } catch (\Aws\S3\Exception\S3Exception $e) {
             $errorcode = $e->getAwsErrorCode();
             // Write could have failed.
@@ -371,7 +371,7 @@ class client extends object_client_base {
             try {
                 $result = $this->client->deleteObject([
                     'Bucket' => $this->bucket,
-                    'Key' => $this->bucketkeyprefix . 'permissions_check_file'
+                    'Key' => $this->bucketkeyprefix . 'permissions_check_file',
                 ]);
                 $permissions->messages[get_string('settings:deletesuccess', 'tool_objectfs')] = 'warning';
                 $permissions->success = false;
@@ -539,7 +539,7 @@ class client extends object_client_base {
      * @return signed_url
      * @throws \Exception
      */
-    public function generate_presigned_url($contenthash, $headers = array()) {
+    public function generate_presigned_url($contenthash, $headers = []) {
         if ('cf' === $this->signingmethod) {
             return  $this->generate_presigned_url_cloudfront($contenthash, $headers);
         }
@@ -828,18 +828,18 @@ class client extends object_client_base {
         } catch (\Exception $e) {
             throw new \coding_exception('Failed to generate pre-signed url: ' . $e->getMessage());
         }
-        $headers = array(
+        $headers = [
             'Range: bytes=' . $ranges->rangefrom . '-' . $ranges->rangeto,
-        );
+        ];
         $curl = new \curl();
-        $curl->setopt(array('CURLOPT_HTTP_VERSION' => CURL_HTTP_VERSION_1_1));
-        $curl->setopt(array('CURLOPT_RETURNTRANSFER' => true));
-        $curl->setopt(array('CURLOPT_SSL_VERIFYPEER' => false));
-        $curl->setopt(array('CURLOPT_CONNECTTIMEOUT' => 15));
-        $curl->setopt(array('CURLOPT_TIMEOUT' => 15));
+        $curl->setopt(['CURLOPT_HTTP_VERSION' => CURL_HTTP_VERSION_1_1]);
+        $curl->setopt(['CURLOPT_RETURNTRANSFER' => true]);
+        $curl->setopt(['CURLOPT_SSL_VERIFYPEER' => false]);
+        $curl->setopt(['CURLOPT_CONNECTTIMEOUT' => 15]);
+        $curl->setopt(['CURLOPT_TIMEOUT' => 15]);
         $curl->setHeader($headers);
         $content = $curl->get($url);
-        return array('responseheaders' => $curl->getResponse(), 'content' => $content, 'url' => $url);
+        return ['responseheaders' => $curl->getResponse(), 'content' => $content, 'url' => $url];
     }
 
     /**

--- a/classes/local/store/s3/file_system.php
+++ b/classes/local/store/s3/file_system.php
@@ -35,8 +35,17 @@ use tool_objectfs\local\store\object_file_system;
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * [Description file_system]
+ */
 class file_system extends object_file_system {
 
+    /**
+     * initialise_external_client
+     * @param \stdClass $config
+     *
+     * @return client
+     */
     protected function initialise_external_client($config) {
         $s3client = new client($config);
 
@@ -44,7 +53,10 @@ class file_system extends object_file_system {
     }
 
     /**
-     * @inheritdoc
+     * readfile
+     * @param \stored_file $file
+     * @return void
+     * @throws \file_exception
      */
     public function readfile(\stored_file $file) {
         $path = $this->get_remote_path_from_storedfile($file);
@@ -66,7 +78,10 @@ class file_system extends object_file_system {
     }
 
     /**
-     * @inheritdoc
+     * copy_from_local_to_external
+     * @param mixed $contenthash
+     *
+     * @return bool
      */
     public function copy_from_local_to_external($contenthash) {
         $localpath = $this->get_local_path_from_hash($contenthash);
@@ -83,7 +98,8 @@ class file_system extends object_file_system {
     }
 
     /**
-     * @inheritdoc
+     * supports_presigned_urls
+     * @return bool
      */
     public function supports_presigned_urls() {
         return true;

--- a/classes/local/store/signed_url.php
+++ b/classes/local/store/signed_url.php
@@ -17,6 +17,8 @@
 namespace tool_objectfs\local\store;
 
 /**
+ * A signed URL for direct downloads
+ *
  * A signed URL which can be used by a user to directly download a file from object store, rather
  * than from the Moodle server.
  *
@@ -36,6 +38,7 @@ class signed_url {
     public $expiresat;
 
     /**
+     * construct
      * @param \moodle_url $url URL to redirect to
      * @param int $expiresat Expiry timestamp (Unix epoch) after which this URL will stop working
      */

--- a/classes/local/store/swift/client.php
+++ b/classes/local/store/swift/client.php
@@ -70,7 +70,7 @@ class client extends object_client_base {
                 'password' => $this->config->openstack_password,
                 'domain' => ['id' => 'default'],
             ],
-            'scope'   => ['project' => ['id' => $this->config->openstack_projectid]]
+            'scope'   => ['project' => ['id' => $this->config->openstack_projectid]],
         ];
 
         if (!isset($this->config->openstack_authtoken['expires_at'])
@@ -179,7 +179,7 @@ class client extends object_client_base {
                 'endpoint' => $this->config->openstack_authurl,
                 'region' => $this->config->openstack_region,
                 'cachedtoken' => $this->config->openstack_authtoken,
-            ]
+            ],
         ]);
         return $context;
     }
@@ -288,7 +288,7 @@ class client extends object_client_base {
     public function test_permissions($testdelete) {
         $permissions = new \stdClass();
         $permissions->success = true;
-        $permissions->messages = array();
+        $permissions->messages = [];
 
         $container = $this->get_container();
 

--- a/classes/local/store/swift/client.php
+++ b/classes/local/store/swift/client.php
@@ -28,6 +28,9 @@ use tool_objectfs\local\store\swift\stream_wrapper;
 use tool_objectfs\local\store\object_client_base;
 use tool_objectfs\local\manager;
 
+/**
+ * [Description client]
+ */
 class client extends object_client_base {
 
     /** @var string $containername The current container. */
@@ -36,7 +39,7 @@ class client extends object_client_base {
     /**
      * The swift client constructor.
      *
-     * @param $config
+     * @param \stdClass $config
      */
     public function __construct($config) {
         global $CFG;
@@ -53,6 +56,10 @@ class client extends object_client_base {
         }
     }
 
+    /**
+     * get_endpoint
+     * @return array
+     */
     private function get_endpoint() {
 
         $endpoint = [
@@ -67,7 +74,12 @@ class client extends object_client_base {
         ];
 
         if (!isset($this->config->openstack_authtoken['expires_at'])
-            || (new \DateTimeImmutable($this->config->openstack_authtoken['expires_at'])) < ( (new \DateTimeImmutable('now'))->add(new \DateInterval('PT1H')))) {
+            || (
+                new \DateTimeImmutable($this->config->openstack_authtoken['expires_at']))
+                <
+                ( (new \DateTimeImmutable('now'))->add(new \DateInterval('PT1H'))
+            )
+        ) {
 
             $lockfactory = \core\lock\lock_config::get_lock_factory('tool_objectfs_swift');
 
@@ -86,13 +98,23 @@ class client extends object_client_base {
         }
 
         // Use the token if it's valid, otherwise clients will need to use username/password auth.
-        if (isset($this->config->openstack_authtoken['expires_at']) && new \DateTimeImmutable($this->config->openstack_authtoken['expires_at']) > new \DateTimeImmutable('now')) {
+        if (
+            isset($this->config->openstack_authtoken['expires_at'])
+            &&
+            new \DateTimeImmutable($this->config->openstack_authtoken['expires_at'])
+            >
+            new \DateTimeImmutable('now')
+           ) {
             $endpoint['cachedToken'] = $this->config->openstack_authtoken;
         }
 
         return $endpoint;
     }
 
+    /**
+     * get_container
+     * @return mixed
+     */
     public function get_container() {
 
         if (empty($this->config->openstack_authurl)) {
@@ -118,7 +140,7 @@ class client extends object_client_base {
                 return;
             }
 
-            stream_wrapper_register('swift', "tool_objectfs\local\store\swift\stream_wrapper") or die("cant create wrapper");
+            stream_wrapper_register('swift', "tool_objectfs\local\store\swift\stream_wrapper") || die("cant create wrapper");
             \tool_objectfs\local\store\swift\stream_wrapper::set_default_context($this->get_seekable_stream_context());
 
             $bootstraped = true;
@@ -129,12 +151,22 @@ class client extends object_client_base {
 
     }
 
+    /**
+     * get_fullpath_from_hash
+     * @param mixed $contenthash
+     *
+     * @return string
+     */
     public function get_fullpath_from_hash($contenthash) {
         $filepath = $this->get_filepath_from_hash($contenthash);
 
         return "swift://$this->containername/$filepath";
     }
 
+    /**
+     * get_seekable_stream_context
+     * @return resource
+     */
     public function get_seekable_stream_context() {
 
         $this->get_endpoint();
@@ -153,6 +185,12 @@ class client extends object_client_base {
     }
 
 
+    /**
+     * get_md5_from_hash
+     * @param mixed $contenthash
+     *
+     * @return mixed
+     */
     private function get_md5_from_hash($contenthash) {
         try {
 
@@ -169,6 +207,13 @@ class client extends object_client_base {
         return $obj->hash;
     }
 
+    /**
+     * verify_object
+     * @param string $contenthash
+     * @param string $localpath
+     *
+     * @return bool
+     */
     public function verify_object($contenthash, $localpath) {
         // For objects uploaded to S3 storage using the multipart upload, the etag will not be the objects MD5.
         // So we can't compare here to verify the object.
@@ -180,6 +225,12 @@ class client extends object_client_base {
         return false;
     }
 
+    /**
+     * get_filepath_from_hash
+     * @param string $contenthash
+     *
+     * @return string
+     */
     protected function get_filepath_from_hash($contenthash) {
         $l1 = $contenthash[0] . $contenthash[1];
         $l2 = $contenthash[2] . $contenthash[3];
@@ -188,6 +239,10 @@ class client extends object_client_base {
     }
 
 
+    /**
+     * test_connection
+     * @return \stdClass
+     */
     public function test_connection() {
 
         $connection = new \stdClass();
@@ -224,6 +279,12 @@ class client extends object_client_base {
         return $connection;
     }
 
+    /**
+     * test_permissions
+     * @param mixed $testdelete
+     *
+     * @return \stdClass
+     */
     public function test_permissions($testdelete) {
         $permissions = new \stdClass();
         $permissions->success = true;
@@ -270,6 +331,12 @@ class client extends object_client_base {
         return $permissions;
     }
 
+    /**
+     * get_exception_details
+     * @param \OpenStack\Common\Error\BadResponseError $e
+     *
+     * @return string
+     */
     protected function get_exception_details(\OpenStack\Common\Error\BadResponseError $e) {
 
         $message = $e->getResponse()->getReasonPhrase();
@@ -285,9 +352,9 @@ class client extends object_client_base {
     /**
      * swift settings form with the following elements:
      *
-     * @param admin_settingpage $settings
-     * @param $config
-     * @return admin_settingpage
+     * @param \admin_settingpage $settings
+     * @param \stdClass $config
+     * @return \admin_settingpage
      */
     public function define_client_section($settings, $config) {
 
@@ -329,7 +396,7 @@ class client extends object_client_base {
     /**
      * Return the error code
      *
-     * @param $e The exception that contains the XML body.
+     * @param \Exception $e The exception that contains the XML body.
      * @return int The error code.
      */
     private function get_error_code($e) {

--- a/classes/local/store/swift/file_system.php
+++ b/classes/local/store/swift/file_system.php
@@ -31,8 +31,17 @@ use tool_objectfs\local\store\object_file_system;
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * [Description file_system]
+ */
 class file_system extends object_file_system {
 
+    /**
+     * initialise_external_client
+     * @param \stdClass $config
+     *
+     * @return client
+     */
     protected function initialise_external_client($config) {
         $client = new client($config);
         return $client;

--- a/classes/local/store/swift/stream_wrapper.php
+++ b/classes/local/store/swift/stream_wrapper.php
@@ -168,9 +168,7 @@ class stream_wrapper {
     private static $defaultcontext;
 
 
-    //
-    // Stream API functions
-    //
+    // Stream API functions.
 
     /**
      * Close directory
@@ -230,10 +228,18 @@ class stream_wrapper {
         return $item->name;
     }
 
+    /**
+     * stream_close
+     * @return bool
+     */
     public function stream_close() {
         return $this->push_object();
     }
 
+    /**
+     * stream_eof
+     * @return bool
+     */
     public function stream_eof() {
         return $this->objstream->eof();
     }
@@ -427,10 +433,10 @@ class stream_wrapper {
     /**
      * Rename object
      *
-     * @param string $path
+     * @param string $currentpath
+     * @param string $destinationpath
      * @return boolean
      */
-
     public function rename($currentpath, $destinationpath) {
         $currenturl = $this->parse_url($currentpath);
         $destinationurl = $this->parse_url($destinationpath);
@@ -488,10 +494,7 @@ class stream_wrapper {
         return $this->generate_stat($object, $container, $object->contentLength);
     }
 
-
-    //
-    // Non-stream API functions
-    //
+    // Non-stream API functions.
 
     /**
      * Set context for functions that don't accept a context. e.g. stat()
@@ -633,7 +636,7 @@ class stream_wrapper {
         $this->isbinary = strpos($mode, 'b') !== false;
         $this->istext = strpos($mode, 't') !== false;
 
-        // rewrite mode to remove b or t:
+        // Rewrite mode to remove b or t:.
         $mode = preg_replace('/[bt]?/', '', $mode);
 
         switch ($mode) {

--- a/classes/local/table/files_table.php
+++ b/classes/local/table/files_table.php
@@ -29,6 +29,9 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir . '/tablelib.php');
 
+/**
+ * [Description files_table]
+ */
 class files_table extends \table_sql {
 
     /**
@@ -62,18 +65,42 @@ class files_table extends \table_sql {
         $this->downloadable = true;
     }
 
+    /**
+     * col_id
+     * @param \stdClass $row
+     *
+     * @return int
+     */
     public function col_id(\stdClass $row) {
         return $row->id;
     }
 
+    /**
+     * col_contextid
+     * @param \stdClass $row
+     *
+     * @return int
+     */
     public function col_contextid(\stdClass $row) {
         return $row->contextid;
     }
 
+    /**
+     * col_contenthash
+     * @param \stdClass $row
+     *
+     * @return string
+     */
     public function col_contenthash(\stdClass $row) {
         return $row->contenthash;
     }
 
+    /**
+     * col_localpath
+     * @param \stdClass $row
+     *
+     * @return string
+     */
     public function col_localpath(\stdClass $row) {
         $l1 = $row->contenthash[0] . $row->contenthash[1];
         $l2 = $row->contenthash[2] . $row->contenthash[3];
@@ -81,34 +108,82 @@ class files_table extends \table_sql {
         return "$l1/$l2";
     }
 
+    /**
+     * col_component
+     * @param \stdClass $row
+     *
+     * @return mixed
+     */
     public function col_component(\stdClass $row) {
         return $row->component;
     }
 
+    /**
+     * col_filearea
+     * @param \stdClass $row
+     *
+     * @return mixed
+     */
     public function col_filearea(\stdClass $row) {
         return $row->filearea;
     }
 
+    /**
+     * col_filename
+     * @param \stdClass $row
+     *
+     * @return mixed
+     */
     public function col_filename(\stdClass $row) {
         return $row->filename;
     }
 
+    /**
+     * col_filepath
+     * @param \stdClass $row
+     *
+     * @return string
+     */
     public function col_filepath(\stdClass $row) {
         return $row->filepath;
     }
 
+    /**
+     * col_mimetype
+     * @param \stdClass $row
+     *
+     * @return string
+     */
     public function col_mimetype(\stdClass $row) {
         return $row->mimetype;
     }
 
+    /**
+     * col_filesize
+     * @param \stdClass $row
+     *
+     * @return mixed
+     */
     public function col_filesize(\stdClass $row) {
         return display_size($row->filesize);
     }
 
+    /**
+     * col_timecreated
+     * @param \stdClass $row
+     *
+     * @return int
+     */
     public function col_timecreated(\stdClass $row) {
         return userdate($row->timecreated);
     }
 
+    /**
+     * col_link
+     * @param \stdClass $row
+     *
+     * @return string
+     */
     public function col_link(\stdClass $row) {
         global $DB;
 

--- a/classes/log/aggregate_logger.php
+++ b/classes/log/aggregate_logger.php
@@ -25,7 +25,7 @@
 
 namespace tool_objectfs\log;
 
-use \tool_objectfs\log\objectfs_statistic;
+use tool_objectfs\log\objectfs_statistic;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -64,14 +64,14 @@ class aggregate_logger extends objectfs_logger {
      */
     public function __construct() {
         parent::__construct();
-        $this->movestatistics = array(
-            OBJECT_LOCATION_ERROR => array(),
-            OBJECT_LOCATION_LOCAL => array(),
-            OBJECT_LOCATION_DUPLICATED => array(),
-            OBJECT_LOCATION_EXTERNAL => array()
-        );
-        $this->readstatistics = array();
-        $this->querystatistics = array();
+        $this->movestatistics = [
+            OBJECT_LOCATION_ERROR => [],
+            OBJECT_LOCATION_LOCAL => [],
+            OBJECT_LOCATION_DUPLICATED => [],
+            OBJECT_LOCATION_EXTERNAL => [],
+        ];
+        $this->readstatistics = [];
+        $this->querystatistics = [];
     }
 
     /**

--- a/classes/log/aggregate_logger.php
+++ b/classes/log/aggregate_logger.php
@@ -31,13 +31,37 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * [Description aggregate_logger]
+ */
 class aggregate_logger extends objectfs_logger {
 
-    private $readstatistics; // 1d array of objectfs_statistics.
-    private $movestatistics; // 2d array of objecfs_statistics that is lazily setup.
+    /**
+     * 1d array of objectfs_statistics.
+     * @var array
+     */
+    private $readstatistics;
+
+    /**
+     * 2d array of objecfs_statistics that is lazily setup.
+     * @var array
+     */
+    private $movestatistics;
+
+    /**
+     * @var mixed
+     */
     private $movement;
+
+    /**
+     * @var array
+     */
     private $querystatistics;
 
+    /**
+     * construct
+     * @return void
+     */
     public function __construct() {
         parent::__construct();
         $this->movestatistics = array(
@@ -50,6 +74,14 @@ class aggregate_logger extends objectfs_logger {
         $this->querystatistics = array();
     }
 
+    /**
+     * log_object_read
+     * @param string $readname
+     * @param string $objectpath
+     * @param int $objectsize
+     *
+     * @return void
+     */
     public function log_object_read($readname, $objectpath, $objectsize = 0) {
         if (array_key_exists($readname, $this->readstatistics)) {
             $readstat = $this->readstatistics[$readname];
@@ -61,6 +93,16 @@ class aggregate_logger extends objectfs_logger {
         $this->readstatistics[$readname] = $readstat;
     }
 
+    /**
+     * log_object_move
+     * @param mixed $movename
+     * @param mixed $initallocation
+     * @param mixed $finallocation
+     * @param mixed $objecthash
+     * @param int $objectsize
+     *
+     * @return void
+     */
     public function log_object_move($movename, $initallocation, $finallocation, $objecthash, $objectsize = 0) {
         if (!$this->movement) {
             $this->movement = $movename;
@@ -76,6 +118,10 @@ class aggregate_logger extends objectfs_logger {
         $this->movestatistics[$initallocation][$finallocation] = $movestat;
     }
 
+    /**
+     * output_move_statistics
+     * @return void
+     */
     public function output_move_statistics() {
         $totaltime = $this->get_timing();
         mtrace("$this->movement. Total time taken: $totaltime seconds. Location change summary:");
@@ -86,6 +132,14 @@ class aggregate_logger extends objectfs_logger {
         }
     }
 
+    /**
+     * output_move_statistic
+     * @param mixed $movestatistic
+     * @param string $initiallocation
+     * @param string $finallocation
+     *
+     * @return void
+     */
     protected function output_move_statistic($movestatistic, $initiallocation, $finallocation) {
         $key = $movestatistic->get_key();
         $objectcount = $movestatistic->get_objectcount();
@@ -96,6 +150,12 @@ class aggregate_logger extends objectfs_logger {
         mtrace("$initiallocation -> $finallocation. Objects moved: $objectcount. Total size: $objectsum. ");
     }
 
+    /**
+     * location_to_string
+     * @param int $location
+     *
+     * @return string
+     */
     public function location_to_string($location) {
         switch ($location) {
             case OBJECT_LOCATION_ERROR:
@@ -113,6 +173,14 @@ class aggregate_logger extends objectfs_logger {
         }
     }
 
+    /**
+     * log_object_query
+     * @param mixed $queryname
+     * @param int $objectcount
+     * @param int $objectsum
+     *
+     * @return [type]
+     */
     public function log_object_query($queryname, $objectcount, $objectsum = 0) {
         if (array_key_exists($queryname, $this->querystatistics)) {
             $querystat = $this->querystatistics[$queryname];

--- a/classes/log/null_logger.php
+++ b/classes/log/null_logger.php
@@ -29,16 +29,45 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * [Description null_logger]
+ */
 class null_logger extends objectfs_logger {
 
+    /**
+     * log_object_read
+     * @param mixed $readname
+     * @param mixed $objectpath
+     * @param int $objectsize
+     *
+     * @return void
+     */
     public function log_object_read($readname, $objectpath, $objectsize = 0) {
         return;
     }
 
+    /**
+     * log_object_move
+     * @param mixed $movename
+     * @param mixed $initallocation
+     * @param mixed $finallocation
+     * @param mixed $objecthash
+     * @param int $objectsize
+     *
+     * @return void
+     */
     public function log_object_move($movename, $initallocation, $finallocation, $objecthash, $objectsize = 0) {
         return;
     }
 
+    /**
+     * log_object_query
+     * @param mixed $queryname
+     * @param mixed $objectcount
+     * @param int $objectsum
+     *
+     * @return void
+     */
     public function log_object_query($queryname, $objectcount, $objectsum = 0) {
         return;
     }

--- a/classes/log/objectfs_logger.php
+++ b/classes/log/objectfs_logger.php
@@ -29,40 +29,104 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * [Description objectfs_logger]
+ */
 abstract class objectfs_logger {
+    /**
+     * @var float
+     */
     protected $timestart;
+    /**
+     * @var float
+     */
     protected $timeend;
 
+    /**
+     * construct
+     */
     public function __construct() {
         $this->timestart = 0;
         $this->timeend = 0;
     }
 
+    /**
+     * start_timing
+     * @return float
+     */
     public function start_timing() {
         $this->timestart = microtime(true);
         return $this->timestart;
     }
 
+    /**
+     * end_timing
+     * @return float
+     */
     public function end_timing() {
         $this->timeend = microtime(true);
         return $this->timeend;
     }
 
+    /**
+     * get_timing
+     * @return float
+     */
     protected function get_timing() {
         return $this->timeend - $this->timestart;
     }
 
+    /**
+     * error_log
+     * @param mixed $error
+     *
+     * @return void
+     */
     public function error_log($error) {
         // @codingStandardsIgnoreStart
         error_log($error);
         // @codingStandardsIgnoreEnd
     }
 
+    /**
+     * log_lock_timing
+     * @param mixed $lock
+     *
+     * @return void
+     */
     public function log_lock_timing($lock) {
         return;
     }
 
+    /**
+     * log_object_read
+     * @param string $readname
+     * @param string $objectpath
+     * @param int $objectsize
+     *
+     * @return void
+     */
     abstract public function log_object_read($readname, $objectpath, $objectsize = 0);
+
+    /**
+     * log_object_move
+     * @param mixed $movename
+     * @param string $initallocation
+     * @param string $finallocation
+     * @param string $objecthash
+     * @param int $objectsize
+     *
+     * @return void
+     */
     abstract public function log_object_move($movename, $initallocation, $finallocation, $objecthash, $objectsize = 0);
+
+    /**
+     * log_object_query
+     * @param string $queryname
+     * @param int $objectcount
+     * @param int $objectsum
+     *
+     * @return void
+     */
     abstract public function log_object_query($queryname, $objectcount, $objectsum = 0);
 }

--- a/classes/log/objectfs_statistic.php
+++ b/classes/log/objectfs_statistic.php
@@ -29,35 +29,78 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * [Description objectfs_statistic]
+ */
 class objectfs_statistic {
 
+    /**
+     * @var string
+     */
     private $key;
+
+    /**
+     * @var int
+     */
     private $objectcount;
+
+    /**
+     * @var int
+     */
     private $objectsum;
 
+    /**
+     * construct
+     * @param string $key
+     */
     public function __construct($key) {
         $this->key = $key;
         $this->objectcount = 0;
         $this->objectsum = 0;
     }
 
+    /**
+     * get_objectcount
+     * @return int
+     */
     public function get_objectcount() {
         return $this->objectcount;
     }
 
+    /**
+     * get_objectsum
+     * @return int
+     */
     public function get_objectsum() {
         return $this->objectsum;
     }
 
+    /**
+     * get_key
+     * @return string
+     */
     public function get_key() {
         return $this->key;
     }
 
+    /**
+     * add_statistic
+     * @param objectfs_statistic $statistic
+     *
+     * @return void
+     */
     public function add_statistic(objectfs_statistic $statistic) {
         $this->objectcount += $statistic->get_objectcount();
         $this->objectsum += $statistic->get_objectsum();
     }
 
+    /**
+     * add_object_data
+     * @param int $objectcount
+     * @param int $objectsum
+     *
+     * @return void
+     */
     public function add_object_data($objectcount, $objectsum) {
         $this->objectcount += $objectcount;
         $this->objectsum += $objectsum;

--- a/classes/log/real_time_logger.php
+++ b/classes/log/real_time_logger.php
@@ -29,16 +29,41 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * [Description real_time_logger]
+ */
 class real_time_logger extends objectfs_logger {
 
+    /**
+     * log_object_read_action
+     * @param string $actionname
+     * @param string $objectpath
+     *
+     * @return mixed
+     */
     public function log_object_read_action($actionname, $objectpath) {
 
     }
 
+    /**
+     * log_object_move_action
+     * @param string $actionname
+     * @param string $objecthash
+     * @param string $initallocation
+     * @param string $finallocation
+     *
+     * @return mixed
+     */
     public function log_object_move_action($actionname, $objecthash, $initallocation, $finallocation) {
 
     }
 
+    /**
+     * append_timing_string
+     * @param mixed $logstring
+     *
+     * @return void
+     */
     protected function append_timing_string(&$logstring) {
         $timetaken = $this->get_timing();
         if ($timetaken > 0) {
@@ -47,6 +72,13 @@ class real_time_logger extends objectfs_logger {
 
     }
 
+    /**
+     * append_size_string
+     * @param string $logstring
+     * @param int $objectsize
+     *
+     * @return void
+     */
     protected function append_size_string(&$logstring, $objectsize) {
         if ($objectsize > 0) {
             $objectsize = display_size($objectsize);
@@ -54,6 +86,14 @@ class real_time_logger extends objectfs_logger {
         }
     }
 
+    /**
+     * append_location_change_string
+     * @param string $logstring
+     * @param string $initiallocation
+     * @param string $finallocation
+     *
+     * @return void
+     */
     protected function append_location_change_string(&$logstring, $initiallocation, $finallocation) {
         if ($initiallocation == $finallocation) {
             $logstring .= "The object location did not change from $initiallocation. ";
@@ -62,6 +102,14 @@ class real_time_logger extends objectfs_logger {
         }
     }
 
+    /**
+     * log_object_read
+     * @param string $readname
+     * @param string $objectpath
+     * @param int $objectsize
+     *
+     * @return [type]
+     */
     public function log_object_read($readname, $objectpath, $objectsize = 0) {
         $logstring = "The read action '$readname' was used on object with path $objectpath. ";
         $this->append_timing_string($logstring);
@@ -73,6 +121,16 @@ class real_time_logger extends objectfs_logger {
         // @codingStandardsIgnoreEnd
     }
 
+    /**
+     * log_object_move
+     * @param string $movename
+     * @param string $initallocation
+     * @param string $finallocation
+     * @param string $objecthash
+     * @param int $objectsize
+     *
+     * @return void
+     */
     public function log_object_move($movename, $initallocation, $finallocation, $objecthash, $objectsize = 0) {
         $logstring = "The move action '$movename' was performed on object with hash $objecthash. ";
         $this->append_location_change_string($logstring, $initallocation, $finallocation);
@@ -83,6 +141,14 @@ class real_time_logger extends objectfs_logger {
         // @codingStandardsIgnoreEnd
     }
 
+    /**
+     * log_object_query
+     * @param string $queryname
+     * @param int $objectcount
+     * @param int $objectsum
+     *
+     * @return void
+     */
     public function log_object_query($queryname, $objectcount, $objectsum = 0) {
         $logstring = "The query action '$queryname' was performed. $objectcount objects were returned";
         $this->append_timing_string($logstring);
@@ -91,6 +157,12 @@ class real_time_logger extends objectfs_logger {
         // @codingStandardsIgnoreEnd
     }
 
+    /**
+     * log_lock_timing
+     * @param mixed $lock
+     *
+     * @return void
+     */
     public function log_lock_timing($lock) {
         $locktime = $this->get_timing();
         if ($lock) {

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -23,13 +23,11 @@
  */
 namespace tool_objectfs\privacy;
 use core_privacy\local\metadata\null_provider;
-use core_privacy\local\legacy_polyfill;
 /**
  * Class provider
  * @package tool_objectfs
  */
 class provider implements null_provider {
-    use legacy_polyfill;
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -26,7 +26,7 @@ use core_privacy\local\metadata\null_provider;
 use core_privacy\local\legacy_polyfill;
 /**
  * Class provider
- * @package tool_objectfs\privacy
+ * @package tool_objectfs
  */
 class provider implements null_provider {
     use legacy_polyfill;
@@ -36,7 +36,7 @@ class provider implements null_provider {
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }

--- a/classes/s3_file_system.php
+++ b/classes/s3_file_system.php
@@ -30,6 +30,9 @@ namespace tool_objectfs;
 
 use tool_objectfs\local\store\s3\file_system;
 
+/**
+ * [Description s3_file_system]
+ */
 class s3_file_system extends file_system {
 
 }

--- a/classes/swift_file_system.php
+++ b/classes/swift_file_system.php
@@ -27,6 +27,9 @@ namespace tool_objectfs;
 
 use tool_objectfs\local\store\swift\file_system;
 
+/**
+ * [Description swift_file_system]
+ */
 class swift_file_system extends file_system {
 
 }

--- a/classes/task/check_objects_location.php
+++ b/classes/task/check_objects_location.php
@@ -27,6 +27,9 @@ namespace tool_objectfs\task;
 
 use tool_objectfs\local\object_manipulator\checker;
 
+/**
+ * [Description check_objects_location]
+ */
 class check_objects_location extends task {
 
     /** @var string $manipulator */

--- a/classes/task/delete_local_empty_directories.php
+++ b/classes/task/delete_local_empty_directories.php
@@ -28,8 +28,9 @@ namespace tool_objectfs\task;
 use coding_exception;
 use tool_objectfs\local\manager;
 
-defined('MOODLE_INTERNAL') || die();
-
+/**
+ * [Description delete_local_empty_directories]
+ */
 class delete_local_empty_directories  extends task {
 
     /** @var string $stringname  */

--- a/classes/task/delete_local_objects.php
+++ b/classes/task/delete_local_objects.php
@@ -28,6 +28,9 @@ namespace tool_objectfs\task;
 use tool_objectfs\local\object_manipulator\deleter;
 
 
+/**
+ * [Description delete_local_objects]
+ */
 class delete_local_objects extends task {
 
     /** @var string $manipulator */

--- a/classes/task/delete_orphaned_object_metadata.php
+++ b/classes/task/delete_orphaned_object_metadata.php
@@ -54,7 +54,7 @@ class delete_orphaned_object_metadata extends task {
 
         $params = [
             'location' => OBJECT_LOCATION_ORPHANED,
-            'ageforremoval' => time() - $ageforremoval
+            'ageforremoval' => time() - $ageforremoval,
         ];
 
         if (!empty($this->config->deleteexternal) && $this->config->deleteexternal == TOOL_OBJECTFS_DELETE_EXTERNAL_TRASH) {

--- a/classes/task/delete_orphaned_object_metadata.php
+++ b/classes/task/delete_orphaned_object_metadata.php
@@ -15,7 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Task that checks for old orphaned objects, and removes their metadata (record)
+ * Task that checks for old orphaned objects
+ *
+ * And removes their metadata (record)
  * and external file (if delete external enabled) as it is no longer useful/relevant.
  *
  * @package   tool_objectfs
@@ -30,6 +32,9 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . '/../../lib.php');
 
+/**
+ * [Description delete_orphaned_object_metadata]
+ */
 class delete_orphaned_object_metadata extends task {
 
     /** @var string $stringname */

--- a/classes/task/generate_status_report.php
+++ b/classes/task/generate_status_report.php
@@ -31,6 +31,9 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . '/../../lib.php');
 
+/**
+ * [Description generate_status_report]
+ */
 class generate_status_report extends task {
 
     /** @var string $stringname */
@@ -38,6 +41,7 @@ class generate_status_report extends task {
 
     /**
      * Execute task
+     * @return void
      */
     public function execute() {
         objectfs_report::cleanup_reports();

--- a/classes/task/orphan_objects.php
+++ b/classes/task/orphan_objects.php
@@ -15,8 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Task that orphans {tool_objectfs_object} records for deleted
- * {files} records.
+ * Task that orphans {tool_objectfs_object} records for deleted {files} records.
  *
  * @package   tool_objectfs
  * @author    Nathan Mares <ngmares@gmail.com>
@@ -29,6 +28,9 @@ namespace tool_objectfs\task;
 use tool_objectfs\local\object_manipulator\orphaner;
 
 
+/**
+ * [Description orphan_objects]
+ */
 class orphan_objects extends task {
 
     /** @var string $manipulator */

--- a/classes/task/pull_objects_from_storage.php
+++ b/classes/task/pull_objects_from_storage.php
@@ -27,6 +27,9 @@ namespace tool_objectfs\task;
 
 use tool_objectfs\local\object_manipulator\puller;
 
+/**
+ * [Description pull_objects_from_storage]
+ */
 class pull_objects_from_storage extends task {
 
     /** @var string $manipulator */

--- a/classes/task/push_objects_to_storage.php
+++ b/classes/task/push_objects_to_storage.php
@@ -27,6 +27,9 @@ namespace tool_objectfs\task;
 
 use tool_objectfs\local\object_manipulator\pusher;
 
+/**
+ * [Description push_objects_to_storage]
+ */
 class push_objects_to_storage extends task {
 
     /** @var string $manipulator */

--- a/classes/task/recover_error_objects.php
+++ b/classes/task/recover_error_objects.php
@@ -27,6 +27,9 @@ namespace tool_objectfs\task;
 
 use tool_objectfs\local\object_manipulator\recoverer;
 
+/**
+ * [Description recover_error_objects]
+ */
 class recover_error_objects extends task {
 
     /** @var string $manipulator */

--- a/classes/task/task.php
+++ b/classes/task/task.php
@@ -35,6 +35,9 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
 
+/**
+ * [Description task]
+ */
 abstract class task extends \core\task\scheduled_task implements objectfs_task {
 
     /** @var stdClass $config */
@@ -68,6 +71,7 @@ abstract class task extends \core\task\scheduled_task implements objectfs_task {
     }
 
     /**
+     * enabled_tasks
      * @return bool
      * @throws coding_exception
      */

--- a/classes/tests/test_azure_integration_client.php
+++ b/classes/tests/test_azure_integration_client.php
@@ -18,16 +18,34 @@ namespace tool_objectfs\tests;
 
 use tool_objectfs\local\store\azure\client;
 
+/**
+ * [Description test_azure_integration_client]
+ * @package tool_objectfs
+ */
 class test_azure_integration_client extends client {
 
+    /**
+     * @var string
+     */
     private $runidentifier;
 
+    /**
+     * construct
+     * @param mixed $config
+     * @return void
+     */
     public function __construct($config) {
         parent::__construct($config);
         $time = microtime();
         $this->runidentifier = md5($time);
     }
 
+    /**
+     * get_filepath_from_hash
+     * @param mixed $contenthash
+     *
+     * @return string
+     */
     protected function get_filepath_from_hash($contenthash) {
         $l1 = $contenthash[0] . $contenthash[1];
         $l2 = $contenthash[2] . $contenthash[3];

--- a/classes/tests/test_client.php
+++ b/classes/tests/test_client.php
@@ -18,12 +18,26 @@ namespace tool_objectfs\tests;
 
 use tool_objectfs\local\store\object_client_base;
 
+/**
+ * [Description test_client]
+ * @package tool_objectfs
+ */
 class test_client extends object_client_base {
-    /** @var int $maxupload Maximum allowed file size that can be uploaded. */
+    /**
+     * Maximum allowed file size that can be uploaded
+     * @var int
+     */
     protected $maxupload;
 
+    /**
+     * @var string
+     */
     private $bucketpath;
 
+    /**
+     * string
+     * @param \stdClass $config
+     */
     public function __construct($config) {
         global $CFG;
         $this->maxupload = 5000000000;
@@ -40,33 +54,73 @@ class test_client extends object_client_base {
         }
     }
 
+    /**
+     * get_seekable_stream_context
+     * @return resource
+     */
     public function get_seekable_stream_context() {
         $context = stream_context_create();
         return $context;
     }
 
+    /**
+     * get_fullpath_from_hash
+     * @param string $contenthash
+     *
+     * @return string
+     */
     public function get_fullpath_from_hash($contenthash) {
         return "$this->bucketpath/{$contenthash}";
     }
 
 
+    /**
+     * delete_file
+     * @param string $fullpath
+     *
+     * @return bool
+     */
     public function delete_file($fullpath) {
         return unlink($fullpath);
     }
 
+    /**
+     * rename_file
+     * @param string $currentpath
+     * @param string $destinationpath
+     *
+     * @return bool
+     */
     public function rename_file($currentpath, $destinationpath) {
         return rename($currentpath, $destinationpath);
     }
 
+    /**
+     * register_stream_wrapper
+     * @return bool
+     */
     public function register_stream_wrapper() {
         return true;
     }
 
+    /**
+     * get_md5_from_hash
+     * @param mixed $contenthash
+     *
+     * @return string
+     */
     private function get_md5_from_hash($contenthash) {
         $path = $this->get_fullpath_from_hash($contenthash);
         return md5_file($path);
     }
 
+    /**
+     * verify_object
+     * @param string $contenthash
+     * @param string $localpath
+     *
+     * @return bool
+     */
     public function verify_object($contenthash, $localpath) {
         // For objects uploaded to S3 storage using the multipart upload, the etag will not be the objects MD5.
         // So we can't compare here to verify the object.
@@ -78,14 +132,28 @@ class test_client extends object_client_base {
         return false;
     }
 
+    /**
+     * test_connection
+     * @return \stdClass
+     */
     public function test_connection() {
         return (object)['success' => true, 'details' => ''];
     }
 
+    /**
+     * test_permissions
+     * @param mixed $testdelete
+     *
+     * @return \stdClass
+     */
     public function test_permissions($testdelete) {
         return (object)['success' => true, 'details' => ''];
     }
 
+    /**
+     * test_permissions
+     * @return int
+     */
     public function get_maximum_upload_size() {
         return $this->maxupload;
     }

--- a/classes/tests/test_digitalocean_integration_client.php
+++ b/classes/tests/test_digitalocean_integration_client.php
@@ -18,16 +18,34 @@ namespace tool_objectfs\tests;
 
 use tool_objectfs\local\store\digitalocean\client;
 
+/**
+ * [Description test_digitalocean_integration_client]
+ * @package tool_objectfs
+ */
 class test_digitalocean_integration_client extends client {
 
+    /**
+     * @var string
+     */
     private $runidentifier;
 
+    /**
+     * construct
+     * @param mixed $config
+     * @return void
+     */
     public function __construct($config) {
         parent::__construct($config);
         $time = microtime();
         $this->runidentifier = md5($time);
     }
 
+    /**
+     * get_filepath_from_hash
+     * @param mixed $contenthash
+     *
+     * @return string
+     */
     protected function get_filepath_from_hash($contenthash) {
         $l1 = $contenthash[0] . $contenthash[1];
         $l2 = $contenthash[2] . $contenthash[3];

--- a/classes/tests/test_file_system.php
+++ b/classes/tests/test_file_system.php
@@ -31,10 +31,22 @@ namespace tool_objectfs\tests;
 use tool_objectfs\local\manager;
 use tool_objectfs\local\store\object_file_system;
 
+/**
+ * [Description test_file_system]
+ */
 class test_file_system extends object_file_system {
 
+    /**
+     * @var int
+     */
     private $maxupload;
 
+    /**
+     * initialise_external_client
+     * @param \stdClass $config
+     *
+     * @return mixed
+     */
     protected function initialise_external_client($config) {
         global $CFG;
         if (isset($CFG->phpunit_objectfs_s3_integration_test_credentials)) {
@@ -71,6 +83,7 @@ class test_file_system extends object_file_system {
     }
 
     /**
+     * get_maximum_upload_size
      * @return float|int
      */
     public function get_maximum_upload_size() {

--- a/classes/tests/test_s3_integration_client.php
+++ b/classes/tests/test_s3_integration_client.php
@@ -18,16 +18,33 @@ namespace tool_objectfs\tests;
 
 use tool_objectfs\local\store\s3\client;
 
+/**
+ * [Description test_s3_integration_client]
+ * @package tool_objectfs
+ */
 class test_s3_integration_client extends client {
 
+    /**
+     * @var string
+     */
     private $runidentifier;
 
+    /**
+     * construct
+     * @param \stdClass $config
+     */
     public function __construct($config) {
         parent::__construct($config);
         $time = microtime();
         $this->runidentifier = md5($time);
     }
 
+    /**
+     * get_filepath_from_hash
+     * @param string $contenthash
+     *
+     * @return string
+     */
     protected function get_filepath_from_hash($contenthash) {
         $l1 = $contenthash[0] . $contenthash[1];
         $l2 = $contenthash[2] . $contenthash[3];

--- a/classes/tests/test_swift_integration_client.php
+++ b/classes/tests/test_swift_integration_client.php
@@ -18,16 +18,33 @@ namespace tool_objectfs\tests;
 
 use tool_objectfs\local\store\swift\client;
 
+/**
+ * [Description test_swift_integration_client]
+ * @package tool_objectfs
+ */
 class test_swift_integration_client extends client {
 
+    /**
+     * @var string
+     */
     private $runidentifier;
 
+    /**
+     * string
+     * @param \stdClass $config
+     */
     public function __construct($config) {
         parent::__construct($config);
         $time = microtime();
         $this->runidentifier = md5($time);
     }
 
+    /**
+     * get_filepath_from_hash
+     * @param string $contenthash
+     *
+     * @return string
+     */
     protected function get_filepath_from_hash($contenthash) {
         $l1 = $contenthash[0] . $contenthash[1];
         $l2 = $contenthash[2] . $contenthash[3];

--- a/classes/tests/testcase.php
+++ b/classes/tests/testcase.php
@@ -72,7 +72,7 @@ abstract class testcase extends \advanced_testcase {
         $itemid    = 0;
         $filepath  = '/';
         $sourcefield = 'Copyright stuff';
-        $filerecord = array(
+        $filerecord = [
             'contextid' => $syscontext->id,
             'component' => $component,
             'filearea'  => $filearea,
@@ -81,7 +81,7 @@ abstract class testcase extends \advanced_testcase {
             'filename'  => $pathname,
             'source'    => $sourcefield,
             'mimetype'  => 'text',
-        );
+        ];
         $file = $fs->create_file_from_pathname($filerecord, $pathname);
 
         manager::update_object_by_hash($file->get_contenthash(), OBJECT_LOCATION_LOCAL);
@@ -102,7 +102,7 @@ abstract class testcase extends \advanced_testcase {
         $itemid    = 0;
         $filepath  = '/';
         $sourcefield = 'Copyright stuff';
-        $filerecord = array(
+        $filerecord = [
             'contextid' => $syscontext->id,
             'component' => $component,
             'filearea'  => $filearea,
@@ -111,7 +111,7 @@ abstract class testcase extends \advanced_testcase {
             'filename'  => md5($content), // Unqiue content should guarentee unique path.
             'source'    => $sourcefield,
             'mimetype'  => 'text',
-        );
+        ];
         $file = $fs->create_file_from_string($filerecord, $content);
 
         manager::update_object_by_hash($file->get_contenthash(), OBJECT_LOCATION_LOCAL);
@@ -331,7 +331,7 @@ abstract class testcase extends \advanced_testcase {
      */
     protected function delete_draft_files($contenthash) {
         global $DB;
-        $DB->delete_records('files', array('contenthash' => $contenthash));
+        $DB->delete_records('files', ['contenthash' => $contenthash]);
     }
 
     /**

--- a/classes/tests/testcase.php
+++ b/classes/tests/testcase.php
@@ -25,6 +25,10 @@ use tool_objectfs\local\object_manipulator\candidates\candidates_finder;
 use tool_objectfs\local\store\object_file_system;
 use tool_objectfs\local\store\signed_url;
 
+/**
+ * [Description testcase]
+ * @package tool_objectfs
+ */
 abstract class testcase extends \advanced_testcase {
 
     /** @var test_file_system Filesystem */
@@ -33,6 +37,10 @@ abstract class testcase extends \advanced_testcase {
     /** @var \tool_objectfs\log\objectfs_logger Logger */
     public $logger;
 
+    /**
+     * setUp
+     * @return void
+     */
     protected function setUp(): void {
         global $CFG;
         $CFG->alternative_file_system_class = '\\tool_objectfs\\tests\\test_file_system';
@@ -42,10 +50,20 @@ abstract class testcase extends \advanced_testcase {
         $this->resetAfterTest(true);
     }
 
+    /**
+     * reset_file_system
+     * @return void
+     */
     protected function reset_file_system() {
         $this->filesystem = new test_file_system();
     }
 
+    /**
+     * create_local_file_from_path
+     * @param string $pathname
+     *
+     * @return stored_file
+     */
     protected function create_local_file_from_path($pathname) {
         $fs = get_file_storage();
         $syscontext = \context_system::instance();
@@ -70,6 +88,12 @@ abstract class testcase extends \advanced_testcase {
         return $file;
     }
 
+    /**
+     * create_local_file
+     * @param string $content
+     *
+     * @return stored_file
+     */
     protected function create_local_file($content = 'test content') {
         $fs = get_file_storage();
         $syscontext = \context_system::instance();
@@ -94,6 +118,12 @@ abstract class testcase extends \advanced_testcase {
         return $file;
     }
 
+    /**
+     * create_duplicated_file
+     * @param string $content
+     *
+     * @return stored_file
+     */
     protected function create_duplicated_file($content = 'test content') {
         $file = $this->create_local_file($content);
         $contenthash = $file->get_contenthash();
@@ -102,6 +132,12 @@ abstract class testcase extends \advanced_testcase {
         return $file;
     }
 
+    /**
+     * create_remote_file
+     * @param string $content
+     *
+     * @return stored_file
+     */
     protected function create_remote_file($content = 'test content') {
         $file = $this->create_duplicated_file($content);
         $contenthash = $file->get_contenthash();
@@ -110,6 +146,10 @@ abstract class testcase extends \advanced_testcase {
         return $file;
     }
 
+    /**
+     * create_error_file
+     * @return stored_file
+     */
     protected function create_error_file() {
         $file = $this->create_local_file();
         $path = $this->get_local_path_from_storedfile($file);
@@ -118,88 +158,188 @@ abstract class testcase extends \advanced_testcase {
         return $file;
     }
 
+    /**
+     * get_external_path_from_hash
+     * @param string $contenthash
+     *
+     * @return mixed
+     */
     protected function get_external_path_from_hash($contenthash) {
         $reflection = new \ReflectionMethod(object_file_system::class, 'get_external_path_from_hash');
         $reflection->setAccessible(true);
         return $reflection->invokeArgs($this->filesystem, [$contenthash]);
     }
 
+    /**
+     * get_external_path_from_storedfile
+     * @param mixed $file
+     *
+     * @return mixed
+     */
     protected function get_external_path_from_storedfile($file) {
         $contenthash = $file->get_contenthash();
         return $this->get_external_path_from_hash($contenthash);
     }
 
-    // We want acces to local path for testing so we use a reflection method as opposed to rewriting here.
+        /**
+         * get_local_path_from_hash
+         *
+         * We want acces to local path for testing so we use a reflection
+         * method as opposed to rewriting here.
+         * @param string $contenthash
+         *
+         * @return mixed
+         */
     protected function get_local_path_from_hash($contenthash) {
         $reflection = new \ReflectionMethod(object_file_system::class, 'get_local_path_from_hash');
         $reflection->setAccessible(true);
         return $reflection->invokeArgs($this->filesystem, [$contenthash]);
     }
 
+    /**
+     * delete_file
+     * @param string $contenthash
+     *
+     * @return mixed
+     */
     protected function delete_file($contenthash) {
         $reflection = new \ReflectionMethod(object_file_system::class, 'delete_file');
         $reflection->setAccessible(true);
         return $reflection->invokeArgs($this->filesystem, [$contenthash]);
     }
 
+    /**
+     * rename_file
+     * @param mixed $currentpath
+     * @param mixed $destinationpath
+     *
+     * @return mixed
+     */
     protected function rename_file($currentpath, $destinationpath) {
         $reflection = new \ReflectionMethod(object_file_system::class, 'rename_file');
         $reflection->setAccessible(true);
         return $reflection->invokeArgs($this->filesystem, [$currentpath, $destinationpath]);
     }
 
+    /**
+     * get_local_path_from_storedfile
+     * @param mixed $file
+     *
+     * @return mixed
+     */
     protected function get_local_path_from_storedfile($file) {
         $contenthash = $file->get_contenthash();
         return $this->get_local_path_from_hash($contenthash);
     }
 
+    /**
+     * recover_file
+     * @param mixed $file
+     *
+     * @return mixed
+     */
     protected function recover_file($file) {
         $reflection = new \ReflectionMethod(object_file_system::class, 'recover_file');
         $reflection->setAccessible(true);
         return $reflection->invokeArgs($this->filesystem, [$file]);
     }
 
+    /**
+     * create_local_object
+     * @param mixed $content
+     *
+     * @return mixed
+     */
     protected function create_local_object($content = 'local object content') {
         $file = $this->create_local_file($content);
         return $this->create_object_record($file, OBJECT_LOCATION_LOCAL);
     }
 
+    /**
+     * create_duplicated_object
+     * @param mixed $content
+     *
+     * @return mixed
+     */
     protected function create_duplicated_object($content = 'duplicated object content') {
         $file = $this->create_duplicated_file($content);
         return $this->create_object_record($file, OBJECT_LOCATION_DUPLICATED);
     }
 
+    /**
+     * create_remote_object
+     * @param mixed $content
+     *
+     * @return mixed
+     */
     protected function create_remote_object($content = 'remote object content') {
         $file = $this->create_remote_file($content);
         return $this->create_object_record($file, OBJECT_LOCATION_EXTERNAL);
     }
 
+    /**
+     * create_error_object
+     * @param mixed $content
+     *
+     * @return mixed
+     */
     protected function create_error_object($content = 'error object content') {
         $file = $this->create_error_file($content);
         return $this->create_object_record($file, OBJECT_LOCATION_ERROR);
     }
 
+    /**
+     * is_locally_readable_by_hash
+     * @param mixed $contenthash
+     *
+     * @return mixed
+     */
     protected function is_locally_readable_by_hash($contenthash) {
         $localpath = $this->get_local_path_from_hash($contenthash);
         return is_readable($localpath);
     }
 
+    /**
+     * is_externally_readable_by_hash
+     * @param mixed $contenthash
+     *
+     * @return mixed
+     */
     protected function is_externally_readable_by_hash($contenthash) {
         $externalpath = $this->get_external_path_from_hash($contenthash);
         return is_readable($externalpath);
     }
 
+    /**
+     * acquire_object_lock
+     * @param mixed $filehash
+     * @param int $timeout
+     *
+     * @return mixed
+     */
     protected function acquire_object_lock($filehash, $timeout = 0) {
         $reflection = new \ReflectionMethod(object_file_system::class, 'acquire_object_lock');
         $reflection->setAccessible(true);
         return $reflection->invokeArgs($this->filesystem, [$filehash, $timeout]);
     }
 
+    /**
+     * delete_draft_files
+     * @param mixed $contenthash
+     *
+     * @return mixed
+     */
     protected function delete_draft_files($contenthash) {
         global $DB;
         $DB->delete_records('files', array('contenthash' => $contenthash));
     }
 
+    /**
+     * is_externally_readable_by_url
+     * @param signed_url $signedurl
+     *
+     * @return mixed
+     */
     protected function is_externally_readable_by_url(signed_url $signedurl) {
         try {
             $file = fopen($signedurl->url->out(false), 'r');
@@ -216,8 +356,9 @@ abstract class testcase extends \advanced_testcase {
     }
 
     /**
+     * create_object_record
      * @param stored_file $file
-     * @param $location
+     * @param mixed $location
      * @return stdClass
      * @throws dml_exception
      */
@@ -233,6 +374,7 @@ abstract class testcase extends \advanced_testcase {
     }
 
     /**
+     * objects_contain_hash
      * @param string $contenthash
      * @return bool
      * @throws moodle_exception

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -25,87 +25,87 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$tasks = array(
-    array(
+$tasks = [
+    [
         'classname' => 'tool_objectfs\task\push_objects_to_storage',
         'blocking'  => 0,
         'minute'    => '*',
         'hour'      => '*',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\generate_status_report',
         'blocking'  => 0,
         'minute'    => '17',
         'hour'     => '*',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\delete_local_objects',
         'blocking'  => 0,
         'minute'    => '*',
         'hour'      => '*',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\orphan_objects',
         'blocking'  => 0,
         'minute'    => 'R',
         'hour'      => 'R',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\delete_orphaned_object_metadata',
         'blocking'  => 0,
         'minute'    => 'R',
         'hour'      => 'R',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\delete_local_empty_directories',
         'blocking'  => 0,
         'minute'    => '0',
         'hour'      => '1',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\pull_objects_from_storage',
         'blocking'  => 0,
         'minute'    => '*',
         'hour'      => '*',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\recover_error_objects',
         'blocking'  => 0,
         'minute'    => '34',
         'hour'      => '*/12',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-    array(
+        'month'     => '*',
+    ],
+    [
         'classname' => 'tool_objectfs\task\check_objects_location',
         'blocking'  => 0,
         'minute'    => 'R',
         'hour'      => '*',
         'day'       => '*',
         'dayofweek' => '*',
-        'month'     => '*'
-    ),
-);
+        'month'     => '*',
+    ],
+];
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -51,7 +51,7 @@ function xmldb_tool_objectfs_upgrade($oldversion) {
 
     if ($oldversion < 2017031000) {
         $table = new xmldb_table('tool_objectfs_objects');
-        $key = new xmldb_key('contenthash', XMLDB_KEY_UNIQUE, array('contenthash'));
+        $key = new xmldb_key('contenthash', XMLDB_KEY_UNIQUE, ['contenthash']);
         $dbman->add_key($table, $key);
 
         upgrade_plugin_savepoint(true, 2017031000, 'tool', 'objectfs');
@@ -111,7 +111,7 @@ function xmldb_tool_objectfs_upgrade($oldversion) {
         $table = new xmldb_table('tool_objectfs_reports');
         $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE);
         $table->add_field('reportdate', XMLDB_TYPE_INTEGER, 10, null, XMLDB_NOTNULL);
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
         $table->add_index('reportdate_idx', XMLDB_INDEX_NOTUNIQUE, ['reportdate']);
         if (!$dbman->table_exists($table)) {
             $dbman->create_table($table);
@@ -124,7 +124,7 @@ function xmldb_tool_objectfs_upgrade($oldversion) {
         $table->add_field('datakey', XMLDB_TYPE_CHAR, 15, null, XMLDB_NOTNULL);
         $table->add_field('objectcount', XMLDB_TYPE_INTEGER, 15, null, XMLDB_NOTNULL);
         $table->add_field('objectsum', XMLDB_TYPE_INTEGER, 20, null, XMLDB_NOTNULL);
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
         $table->add_index('reporttype_idx', XMLDB_INDEX_NOTUNIQUE, ['reporttype']);
         $table->add_index('reportid_idx', XMLDB_INDEX_NOTUNIQUE, ['reportid']);
         if (!$dbman->table_exists($table)) {

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -23,6 +23,12 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+/**
+ * xmldb_tool_objectfs_upgrade
+ * @param int $oldversion
+ *
+ * @return bool
+ */
 function xmldb_tool_objectfs_upgrade($oldversion) {
     global $DB;
     $dbman = $DB->get_manager();

--- a/lib.php
+++ b/lib.php
@@ -71,8 +71,8 @@ define('TOOL_OBJECTFS_DELETE_EXTERNAL_FULL', 2);
 
 /**
  * Sends a plugin file to the browser.
- * @param $course
- * @param $cm
+ * @param mixed $course
+ * @param mixed $cm
  * @param \context $context
  * @param string $filearea
  * @param array $args

--- a/lib.php
+++ b/lib.php
@@ -103,7 +103,7 @@ function tool_objectfs_pluginfile($course, $cm, context $context, $filearea, arr
 function tool_objectfs_status_checks() {
     if (get_config('tool_objectfs', 'proxyrangerequests')) {
         return [
-            new tool_objectfs\check\proxy_range_request()
+            new tool_objectfs\check\proxy_range_request(),
         ];
     }
 

--- a/object_location.php
+++ b/object_location.php
@@ -31,7 +31,7 @@ require_once($CFG->libdir.'/tablelib.php');
 admin_externalpage_setup('tool_objectfs_object_location_history');
 
 $logformat   = optional_param('download', '', PARAM_ALPHA);
-$params = array();
+$params = [];
 if ($logformat) {
     $params['download'] = $logformat;
 }

--- a/presignedurl_tests.php
+++ b/presignedurl_tests.php
@@ -58,7 +58,7 @@ if ($support) {
     $deletelinktext = get_string('settings:presignedurl:deletefiles', OBJECTFS_PLUGIN_NAME);
     echo $output->heading(html_writer::link($deleteurl, $deletelinktext) . $deletedsuccess, 6);
     $client = manager::get_client($config);
-    if ($client and $client->get_availability()) {
+    if ($client && $client->get_availability()) {
         $connection = $client->test_connection();
         if ($connection->success) {
             $testfiles = $output->presignedurl_tests_load_files($fs);

--- a/renderer.php
+++ b/renderer.php
@@ -27,6 +27,9 @@ use tool_objectfs\local\manager;
 use tool_objectfs\local\report\objectfs_report;
 use tool_objectfs\local\store\object_file_system;
 
+/**
+ * [Description tool_objectfs_renderer]
+ */
 class tool_objectfs_renderer extends plugin_renderer_base {
 
     /**
@@ -50,6 +53,12 @@ class tool_objectfs_renderer extends plugin_renderer_base {
         }
     }
 
+    /**
+     * presignedurl_tests_load_files
+     * @param mixed $fs
+     *
+     * @return array
+     */
     public function presignedurl_tests_load_files($fs) {
         global $CFG;
         $filestorage = get_file_storage();
@@ -95,6 +104,13 @@ class tool_objectfs_renderer extends plugin_renderer_base {
         return $testfiles;
     }
 
+    /**
+     * presignedurl_tests_content
+     * @param mixed $fs
+     * @param mixed $testfiles
+     *
+     * @return string
+     */
     public function presignedurl_tests_content($fs, $testfiles) {
         global $CFG;
         $CFG->enablepresignedurls = true;

--- a/renderer.php
+++ b/renderer.php
@@ -79,14 +79,14 @@ class tool_objectfs_renderer extends plugin_renderer_base {
             $itemid = 0;
             $filepath = '/';
 
-            $filerecord = array(
+            $filerecord = [
                 'contextid' => $contextid,
                 'component' => $component,
                 'filearea'  => $filearea,
                 'itemid'    => $itemid,
                 'filepath'  => $filepath,
-                'filename'  => $testfilename
-            );
+                'filename'  => $testfilename,
+            ];
 
             $testfile = $filestorage->get_file($contextid, $component, $filearea, $itemid, $filepath, $testfilename);
             if (!$testfile) {
@@ -236,15 +236,15 @@ class tool_objectfs_renderer extends plugin_renderer_base {
 
         $baseurl = '/admin/tool/objectfs/object_status.php';
 
-        $previd = array();
-        $nextid = array();
-        $prevdisabled = array('disabled' => true);
-        $nextdisabled = array('disabled' => true);
+        $previd = [];
+        $nextid = [];
+        $prevdisabled = ['disabled' => true];
+        $nextdisabled = ['disabled' => true];
 
         end($reports);
-        $oldestid = array('reportid' => key($reports));
+        $oldestid = ['reportid' => key($reports)];
         reset($reports);
-        $latestid = array('reportid' => key($reports));
+        $latestid = ['reportid' => key($reports)];
 
         while ($reportid != key($reports)) {
             next($reports);
@@ -252,7 +252,7 @@ class tool_objectfs_renderer extends plugin_renderer_base {
 
         if (next($reports)) {
             $previd = ['reportid' => key($reports)];
-            $prevdisabled = array();
+            $prevdisabled = [];
             prev($reports);
         } else {
             end($reports);
@@ -260,7 +260,7 @@ class tool_objectfs_renderer extends plugin_renderer_base {
 
         if (prev($reports)) {
             $nextid = ['reportid' => key($reports)];
-            $nextdisabled = array();
+            $nextdisabled = [];
             next($reports);
         } else {
             reset($reports);

--- a/tests/local/manager_test.php
+++ b/tests/local/manager_test.php
@@ -38,7 +38,7 @@ class manager_test extends \tool_objectfs\tests\testcase {
      *
      * @return array
      */
-    public function all_extensions_whitelisted_provider() {
+    public static function all_extensions_whitelisted_provider(): array {
         return [
             [null, false],
             ['', false],
@@ -69,7 +69,7 @@ class manager_test extends \tool_objectfs\tests\testcase {
      *
      * @return array
      */
-    public function is_extension_whitelisted_provider() {
+    public static function is_extension_whitelisted_provider(): array {
         return [
             [null, 'file.tar', false],
             ['', 'file.tar', false],
@@ -103,7 +103,7 @@ class manager_test extends \tool_objectfs\tests\testcase {
      *
      * @return array
      */
-    public function get_header_provider() {
+    public static function get_header_provider(): array {
         return [
             [[], '', ''],
             [[], 'Missing header', ''],

--- a/tests/local/object_manipulator/checker_test.php
+++ b/tests/local/object_manipulator/checker_test.php
@@ -22,6 +22,7 @@ use tool_objectfs\local\manager;
  * Tests for object checker.
  *
  * @covers \tool_objectfs\local\object_manipulator\checker
+ * @package tool_objectfs
  */
 class checker_test extends \tool_objectfs\tests\testcase {
 

--- a/tests/local/object_manipulator/checker_test.php
+++ b/tests/local/object_manipulator/checker_test.php
@@ -48,7 +48,7 @@ class checker_test extends \tool_objectfs\tests\testcase {
     public function test_checker_get_location_local_if_object_is_local() {
         global $DB;
         $file = $this->create_local_object();
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $file->contenthash]);
         $this->assertEquals('string', gettype($location));
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $location);
     }
@@ -56,7 +56,7 @@ class checker_test extends \tool_objectfs\tests\testcase {
     public function test_checker_get_location_duplicated_if_object_is_duplicated() {
         global $DB;
         $file = $this->create_duplicated_object();
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $file->contenthash]);
         $this->assertEquals('string', gettype($location));
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
     }
@@ -64,7 +64,7 @@ class checker_test extends \tool_objectfs\tests\testcase {
     public function test_checker_get_location_external_if_object_is_external() {
         global $DB;
         $file = $this->create_remote_object();
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $file->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $file->contenthash]);
         $this->assertEquals('string', gettype($location));
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
     }
@@ -82,7 +82,7 @@ class checker_test extends \tool_objectfs\tests\testcase {
     public function test_checker_get_candidate_objects_will_get_object() {
         global $DB;
         $localobject = $this->create_local_object('test_checker_get_candidate_objects_will_get_object');
-        $DB->delete_records('tool_objectfs_objects', array('contenthash' => $localobject->contenthash));
+        $DB->delete_records('tool_objectfs_objects', ['contenthash' => $localobject->contenthash]);
 
         self::assertTrue($this->objects_contain_hash($localobject->contenthash));
     }
@@ -104,27 +104,27 @@ class checker_test extends \tool_objectfs\tests\testcase {
         $file = $this->create_local_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $this->assertEquals(OBJECT_LOCATION_LOCAL, $reflection->invokeArgs($this->checker, array($file)));
+        $this->assertEquals(OBJECT_LOCATION_LOCAL, $reflection->invokeArgs($this->checker, [$file]));
     }
 
     public function test_checker_manipulate_object_method_will_get_correct_location_if_file_is_duplicated() {
         $file = $this->create_duplicated_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $reflection->invokeArgs($this->checker, array($file)));
+        $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $reflection->invokeArgs($this->checker, [$file]));
     }
 
     public function test_checker_manipulate_object_method_will_get_correct_location_if_file_is_external() {
         $file = $this->create_remote_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $reflection->invokeArgs($this->checker, array($file)));
+        $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $reflection->invokeArgs($this->checker, [$file]));
     }
 
     public function test_checker_manipulate_object_method_will_get_error_location_on_error_file() {
         $file = $this->create_error_object();
         $reflection = new \ReflectionMethod(checker::class, "manipulate_object");
         $reflection->setAccessible(true);
-        $this->assertEquals(OBJECT_LOCATION_ERROR, $reflection->invokeArgs($this->checker, array($file)));
+        $this->assertEquals(OBJECT_LOCATION_ERROR, $reflection->invokeArgs($this->checker, [$file]));
     }
 }

--- a/tests/local/object_manipulator/deleter_test.php
+++ b/tests/local/object_manipulator/deleter_test.php
@@ -22,6 +22,7 @@ use tool_objectfs\local\manager;
  * Tests for object deleter.
  *
  * @covers \tool_objectfs\local\object_manipulator\deleter
+ * @package tool_objectfs
  */
 class deleter_test extends \tool_objectfs\tests\testcase {
 
@@ -47,6 +48,13 @@ class deleter_test extends \tool_objectfs\tests\testcase {
         ob_end_clean();
     }
 
+    /**
+     * set_deleter_config
+     * @param mixed $key
+     * @param mixed $value
+     *
+     * @return void
+     */
     protected function set_deleter_config($key, $value) {
         $config = manager::get_objectfs_config();
         $config->$key = $value;

--- a/tests/local/object_manipulator/deleter_test.php
+++ b/tests/local/object_manipulator/deleter_test.php
@@ -87,9 +87,9 @@ class deleter_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_duplicated_object();
 
-        $this->deleter->execute(array($object));
+        $this->deleter->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
         $this->assertFalse($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -99,9 +99,9 @@ class deleter_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_local_object();
 
-        $this->deleter->execute(array($object));
+        $this->deleter->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertFalse($this->is_externally_readable_by_hash($object->contenthash));
@@ -111,9 +111,9 @@ class deleter_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_remote_object();
 
-        $this->deleter->execute(array($object));
+        $this->deleter->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
         $this->assertFalse($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -124,9 +124,9 @@ class deleter_test extends \tool_objectfs\tests\testcase {
         $object = $this->create_duplicated_object();
         $this->set_deleter_config('deletelocal', 0);
 
-        $this->deleter->execute(array($object));
+        $this->deleter->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -134,7 +134,7 @@ class deleter_test extends \tool_objectfs\tests\testcase {
 
     public function test_deleter_can_delete_multiple_objects() {
         global $DB;
-        $objects = array();
+        $objects = [];
         for ($i = 0; $i < 5; $i++) {
             $objects[] = $this->create_duplicated_object("Object $i");
         }
@@ -142,7 +142,7 @@ class deleter_test extends \tool_objectfs\tests\testcase {
         $this->deleter->execute($objects);
 
         foreach ($objects as $object) {
-            $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+            $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
             $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
             $this->assertFalse($this->is_locally_readable_by_hash($object->contenthash));
             $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));

--- a/tests/local/object_manipulator/orphaner_test.php
+++ b/tests/local/object_manipulator/orphaner_test.php
@@ -96,7 +96,7 @@ class orphaner_test extends \tool_objectfs\tests\testcase {
 
         // Update that object to have a different hash, to mock a non-existent
         // mdl_file with an objectfs record (orphaned).
-        $DB->set_field('files', 'contenthash', 'different', array('contenthash' => $object->contenthash));
+        $DB->set_field('files', 'contenthash', 'different', ['contenthash' => $object->contenthash]);
 
         // Expect one candidate - no matching contenthash in {files}.
         $objects = $finder->get();

--- a/tests/local/object_manipulator/orphaner_test.php
+++ b/tests/local/object_manipulator/orphaner_test.php
@@ -23,6 +23,7 @@ use tool_objectfs\local\object_manipulator\candidates\candidates_finder;
  * Tests for object orphaner.
  *
  * @covers \tool_objectfs\local\object_manipulator\orphaner
+ * @package tool_objectfs
  */
 class orphaner_test extends \tool_objectfs\tests\testcase {
 
@@ -47,6 +48,13 @@ class orphaner_test extends \tool_objectfs\tests\testcase {
         ob_end_clean();
     }
 
+    /**
+     * set_orphaner_config
+     * @param mixed $key
+     * @param mixed $value
+     *
+     * @return void
+     */
     protected function set_orphaner_config($key, $value) {
         $config = manager::get_objectfs_config();
         $config->$key = $value;

--- a/tests/local/object_manipulator/puller_test.php
+++ b/tests/local/object_manipulator/puller_test.php
@@ -77,7 +77,7 @@ class puller_test extends \tool_objectfs\tests\testcase {
     public function test_puller_get_candidate_objects_will_not_get_objects_over_sizethreshold() {
         global $DB;
         $remoteobject = $this->create_remote_object();
-        $DB->set_field('files', 'filesize', 10, array('contenthash' => $remoteobject->contenthash));
+        $DB->set_field('files', 'filesize', 10, ['contenthash' => $remoteobject->contenthash]);
         $this->set_puller_config('sizethreshold', 0);
 
         self::assertFalse($this->objects_contain_hash($remoteobject->contenthash));
@@ -87,9 +87,9 @@ class puller_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_remote_object();
 
-        $this->puller->execute(array($object));
+        $this->puller->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -99,9 +99,9 @@ class puller_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_duplicated_object();
 
-        $this->puller->execute(array($object));
+        $this->puller->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -111,9 +111,9 @@ class puller_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_local_object();
 
-        $this->puller->execute(array($object));
+        $this->puller->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertFalse($this->is_externally_readable_by_hash($object->contenthash));

--- a/tests/local/object_manipulator/puller_test.php
+++ b/tests/local/object_manipulator/puller_test.php
@@ -22,6 +22,7 @@ use tool_objectfs\local\manager;
  * Tests for object puller.
  *
  * @covers \tool_objectfs\local\object_manipulator\puller
+ * @package tool_objectfs
  */
 class puller_test extends \tool_objectfs\tests\testcase {
 
@@ -45,6 +46,13 @@ class puller_test extends \tool_objectfs\tests\testcase {
         ob_end_clean();
     }
 
+    /**
+     * set_puller_config
+     * @param mixed $key
+     * @param mixed $value
+     *
+     * @return void
+     */
     protected function set_puller_config($key, $value) {
         $config = manager::get_objectfs_config();
         $config->$key = $value;

--- a/tests/local/object_manipulator/pusher_test.php
+++ b/tests/local/object_manipulator/pusher_test.php
@@ -80,7 +80,7 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_local_object();
         $maximumfilesize = $this->filesystem->get_maximum_upload_filesize() + 1;
-        $DB->set_field('tool_objectfs_objects', 'filesize', $maximumfilesize, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'filesize', $maximumfilesize, ['contenthash' => $object->contenthash]);
 
         self::assertFalse($this->objects_contain_hash($object->contenthash));
     }
@@ -89,7 +89,7 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $this->set_pusher_config('sizethreshold', 100);
         $object = $this->create_local_object();
-        $DB->set_field('tool_objectfs_objects', 'filesize', 10, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'filesize', 10, ['contenthash' => $object->contenthash]);
 
         self::assertFalse($this->objects_contain_hash($object->contenthash));
     }
@@ -105,9 +105,9 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_local_object();
 
-        $this->pusher->execute(array($object));
+        $this->pusher->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -117,9 +117,9 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_duplicated_object();
 
-        $this->pusher->execute(array($object));
+        $this->pusher->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
         $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -129,9 +129,9 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         global $DB;
         $object = $this->create_remote_object();
 
-        $this->pusher->execute(array($object));
+        $this->pusher->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
         $this->assertFalse($this->is_locally_readable_by_hash($object->contenthash));
         $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -139,7 +139,7 @@ class pusher_test extends \tool_objectfs\tests\testcase {
 
     public function test_pusher_can_push_multiple_objects() {
         global $DB;
-        $objects = array();
+        $objects = [];
         for ($i = 0; $i < 5; $i++) {
             $objects[] = $this->create_local_object("Object $i");
         }
@@ -147,7 +147,7 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         $this->pusher->execute($objects);
 
         foreach ($objects as $object) {
-            $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+            $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
             $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
             $this->assertTrue($this->is_locally_readable_by_hash($object->contenthash));
             $this->assertTrue($this->is_externally_readable_by_hash($object->contenthash));
@@ -164,7 +164,7 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         $this->pusher->execute($objects);
 
         $object = $this->create_local_object();
-        $file = $DB->get_record('files', array('contenthash' => $object->contenthash));
+        $file = $DB->get_record('files', ['contenthash' => $object->contenthash]);
 
         // Update mimetype to something different and insert as new file.
         $file->mimetype = "differentMimeType";

--- a/tests/local/object_manipulator/pusher_test.php
+++ b/tests/local/object_manipulator/pusher_test.php
@@ -23,6 +23,7 @@ use tool_objectfs\local\object_manipulator\candidates\candidates_finder;
  * Tests for object pusher.
  *
  * @covers \tool_objectfs\local\object_manipulator\pusher
+ * @package tool_objectfs
  */
 class pusher_test extends \tool_objectfs\tests\testcase {
 
@@ -47,6 +48,13 @@ class pusher_test extends \tool_objectfs\tests\testcase {
         ob_end_clean();
     }
 
+    /**
+     * set_pusher_config
+     * @param mixed $key
+     * @param mixed $value
+     *
+     * @return void
+     */
     protected function set_pusher_config($key, $value) {
         $config = manager::get_objectfs_config();
         $config->$key = $value;

--- a/tests/local/object_manipulator/recoverer_test.php
+++ b/tests/local/object_manipulator/recoverer_test.php
@@ -23,6 +23,7 @@ use tool_objectfs\local\object_manipulator\candidates\candidates_finder;
  * Tests for object recoverer.
  *
  * @covers \tool_objectfs\local\object_manipulator\recoverer
+ * @package tool_objectfs
  */
 class recoverer_test extends \tool_objectfs\tests\testcase {
 

--- a/tests/local/object_manipulator/recoverer_test.php
+++ b/tests/local/object_manipulator/recoverer_test.php
@@ -59,44 +59,44 @@ class recoverer_test extends \tool_objectfs\tests\testcase {
     public function test_recoverer_will_recover_local_objects() {
         global $DB;
         $object = $this->create_local_object();
-        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, ['contenthash' => $object->contenthash]);
 
-        $this->recoverer->execute(array($object));
+        $this->recoverer->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_LOCAL, $location);
     }
 
     public function test_recoverer_will_recover_duplicated_objects() {
         global $DB;
         $object = $this->create_duplicated_object();
-        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, ['contenthash' => $object->contenthash]);
 
-        $this->recoverer->execute(array($object));
+        $this->recoverer->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_DUPLICATED, $location);
     }
 
     public function test_recoverer_will_recover_remote_objects() {
         global $DB;
         $object = $this->create_remote_object();
-        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, ['contenthash' => $object->contenthash]);
 
-        $this->recoverer->execute(array($object));
+        $this->recoverer->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_EXTERNAL, $location);
     }
 
     public function test_recoverer_will_not_recover_error_objects() {
         global $DB;
         $object = $this->create_error_object();
-        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, array('contenthash' => $object->contenthash));
+        $DB->set_field('tool_objectfs_objects', 'location', OBJECT_LOCATION_ERROR, ['contenthash' => $object->contenthash]);
 
-        $this->recoverer->execute(array($object));
+        $this->recoverer->execute([$object]);
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $object->contenthash));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $object->contenthash]);
         $this->assertEquals(OBJECT_LOCATION_ERROR, $location);
     }
 }

--- a/tests/local/report/object_status_test.php
+++ b/tests/local/report/object_status_test.php
@@ -168,7 +168,7 @@ class object_status_test extends \tool_objectfs\tests\testcase {
      *
      * @return array
      */
-    public function object_status_add_barchart_method_provider() {
+    public static function object_status_add_barchart_method_provider(): array {
         return [
             [0, 0, '', 0, '0'],
             [0, 100, 'count', 0, '<div class="ofs-bar" style="width:0%">' . number_format(0) . '</div>'],
@@ -212,7 +212,7 @@ class object_status_test extends \tool_objectfs\tests\testcase {
      *
      * @return array
      */
-    public function object_status_get_size_range_from_logsize_provider() {
+    public static function object_status_get_size_range_from_logsize_provider(): array {
         return [
             ['1', '< ' . display_size(1024)],
             ['10', display_size(1024) . ' - ' . display_size(2048)],

--- a/tests/local/store/clients_test.php
+++ b/tests/local/store/clients_test.php
@@ -16,8 +16,8 @@
 
 namespace tool_objectfs\local\store;
 
-use \tool_objectfs\tests\test_digitalocean_integration_client as digitaloceanclient;
-use \tool_objectfs\tests\test_s3_integration_client as s3client;
+use tool_objectfs\tests\test_digitalocean_integration_client as digitaloceanclient;
+use tool_objectfs\tests\test_s3_integration_client as s3client;
 
 /**
  * Client tests.
@@ -32,7 +32,7 @@ class clients_test extends \advanced_testcase {
      *
      * @return \array[][]
      */
-    public function s3_client_test_connection_if_not_configured_properly_data_provider() {
+    public static function s3_client_test_connection_if_not_configured_properly_data_provider(): array {
         return [
             [[]],
             [['s3_bucket' => '', 's3_region' => 'test', 's3_usesdkcreds' => 0, 's3_key' => 'test', 's3_secret' => 'test']],
@@ -72,7 +72,7 @@ class clients_test extends \advanced_testcase {
      *
      * @return \array[][]
      */
-    public function digitalocean_client_test_connection_if_not_configured_properly_data_provider() {
+    public static function digitalocean_client_test_connection_if_not_configured_properly_data_provider(): array {
         return [
             [[]],
             [['do_key' => '', 'do_secret' => '', 'do_region' => '']],

--- a/tests/local/tasks_test.php
+++ b/tests/local/tasks_test.php
@@ -20,6 +20,7 @@ namespace tool_objectfs\local;
  * End to end tests for tasks. Make sure all the plumbing is ok.
  *
  * @covers \tool_objectfs\local\manager
+ * @package tool_objectfs
  */
 class tasks_test extends \tool_objectfs\tests\testcase {
 

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -24,9 +24,17 @@ use tool_objectfs\tests\test_file_system;
  * Test basic operations of object file system.
  *
  * @covers \tool_objectfs\local\store\object_file_system
+ * @package tool_objectfs
  */
 class object_file_system_test extends tests\testcase {
 
+    /**
+     * set_externalclient_config
+     * @param mixed $key
+     * @param mixed $value
+     *
+     * @return void
+     */
     public function set_externalclient_config($key, $value) {
         // Get a reflection of externalclient object as a property.
         $reflection = new \ReflectionClass($this->filesystem);
@@ -223,6 +231,7 @@ class object_file_system_test extends tests\testcase {
     }
 
     /**
+     * delete_empty_folders_provider
      * @return array
      */
     public function delete_empty_folders_provider() {
@@ -268,6 +277,7 @@ class object_file_system_test extends tests\testcase {
     }
 
     /**
+     * test_delete_empty_folders_provider
      * @dataProvider delete_empty_folders_provider
      * @param array $dirs Dirs to be created.
      * @param array $files Files to be created.
@@ -364,6 +374,10 @@ class object_file_system_test extends tests\testcase {
         $this->assertEquals(OBJECT_LOCATION_ERROR, $location);
     }
 
+    /**
+     * error_surpressor
+     * @return void
+     */
     public function error_surpressor() {
         // We do nothing. We cant surpess warnings
         // normally because phpunit will still fail.
@@ -636,6 +650,10 @@ class object_file_system_test extends tests\testcase {
         $this->assertTrue($this->filesystem->presigned_url_configured());
     }
 
+    /**
+     * presigned_url_should_redirect_provider
+     * @return array
+     */
     public function presigned_url_should_redirect_provider() {
         $provider = array();
 
@@ -675,11 +693,12 @@ class object_file_system_test extends tests\testcase {
     }
 
     /**
-     * @dataProvider presigned_url_should_redirect_provider
+     * test_presigned_url_should_redirect_provider
      *
-     * @param $enablepresignedurls mixed enable pre-signed URLs.
-     * @param $presignedminfilesize mixed minimum file size to be redirected to pre-signed URL.
-     * @param $result boolean expected result.
+     * @dataProvider presigned_url_should_redirect_provider
+     * @param mixed $enablepresignedurls enable pre-signed URLs.
+     * @param mixed $presignedminfilesize minimum file size to be redirected to pre-signed URL.
+     * @param bool $result expected result.
      * @throws \dml_exception
      */
     public function test_presigned_url_should_redirect_method_with_data_provider($enablepresignedurls,
@@ -737,7 +756,8 @@ class object_file_system_test extends tests\testcase {
             [7200, $now, userdate($now - 100, '%a, %d %b %Y %H:%M:%S'), $now + (2 * MINSECS) - $secondsafternowsub100],
             [7200, $now, userdate($now + 30, '%a, %d %b %Y %H:%M:%S'), $now + (2 * MINSECS) - $secondsafternowadd30],
             [7200, $now, userdate($now + 100, '%a, %d %b %Y %H:%M:%S'), $now + (2 * MINSECS) - $secondsafternowadd100],
-            [7200, $now, userdate($now + WEEKSECS + HOURSECS, '%a, %d %b %Y %H:%M:%S'), $now + WEEKSECS - MINSECS - $secondsafternowaddweek],
+            [7200, $now, userdate($now + WEEKSECS + HOURSECS, '%a, %d %b %Y %H:%M:%S'),
+            $now + WEEKSECS - MINSECS - $secondsafternowaddweek],
 
             // Custom Pre-Signed URL expiration time and int-like 'Expires' header.
             [0, $now, 0, $now + (2 * MINSECS) - $secondsafternow],
@@ -753,7 +773,8 @@ class object_file_system_test extends tests\testcase {
             [600, $now, userdate($now - 100, '%a, %d %b %Y %H:%M:%S'), $now + (2 * MINSECS) - $secondsafternowsub100],
             [600, $now, userdate($now + 30, '%a, %d %b %Y %H:%M:%S'), $now + (2 * MINSECS) - $secondsafternowadd30],
             [600, $now, userdate($now + 100, '%a, %d %b %Y %H:%M:%S'), $now + (2 * MINSECS) - $secondsafternowadd100],
-            [600, $now, userdate($now + WEEKSECS + HOURSECS, '%a, %d %b %Y %H:%M:%S'), $now + WEEKSECS - MINSECS - $secondsafternowaddweek],
+            [600, $now, userdate($now + WEEKSECS + HOURSECS, '%a, %d %b %Y %H:%M:%S'),
+            $now + WEEKSECS - MINSECS - $secondsafternowaddweek],
         ];
     }
 

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -234,7 +234,7 @@ class object_file_system_test extends tests\testcase {
      * delete_empty_folders_provider
      * @return array
      */
-    public function delete_empty_folders_provider() {
+    public static function delete_empty_folders_provider(): array {
         return [
             [
                 /*
@@ -334,11 +334,11 @@ class object_file_system_test extends tests\testcase {
 
         // Phpunit will fail if PHP warning is thrown (which we want)
         // so we surpress here.
-        set_error_handler(array($this, 'error_surpressor'));
+        set_error_handler([$this, 'error_surpressor']);
         $this->filesystem->readfile($fakefile);
         restore_error_handler();
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $fakefile->get_contenthash()));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $fakefile->get_contenthash()]);
         $this->assertEquals(OBJECT_LOCATION_ERROR, $location);
     }
 
@@ -366,11 +366,11 @@ class object_file_system_test extends tests\testcase {
 
         // Phpunit will fail if PHP warning is thrown (which we want)
         // so we surpress here.
-        set_error_handler(array($this, 'error_surpressor'));
+        set_error_handler([$this, 'error_surpressor']);
         $this->filesystem->get_content($fakefile);
         restore_error_handler();
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $fakefile->get_contenthash()));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $fakefile->get_contenthash()]);
         $this->assertEquals(OBJECT_LOCATION_ERROR, $location);
     }
 
@@ -389,11 +389,11 @@ class object_file_system_test extends tests\testcase {
 
         // Phpunit will fail if PHP warning is thrown (which we want)
         // so we surpress here.
-        set_error_handler(array($this, 'error_surpressor'));
+        set_error_handler([$this, 'error_surpressor']);
         $this->filesystem->xsendfile($fakefile->get_contenthash());
         restore_error_handler();
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $fakefile->get_contenthash()));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $fakefile->get_contenthash()]);
         $this->assertEquals(OBJECT_LOCATION_ERROR, $location);
     }
 
@@ -429,11 +429,11 @@ class object_file_system_test extends tests\testcase {
 
         // Phpunit will fail if PHP warning is thrown (which we want)
         // so we surpress here.
-        set_error_handler(array($this, 'error_surpressor'));
+        set_error_handler([$this, 'error_surpressor']);
         $filehandle = $this->filesystem->get_content_file_handle($fakefile);
         restore_error_handler();
 
-        $location = $DB->get_field('tool_objectfs_objects', 'location', array('contenthash' => $fakefile->get_contenthash()));
+        $location = $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $fakefile->get_contenthash()]);
         $this->assertEquals(OBJECT_LOCATION_ERROR, $location);
     }
 
@@ -443,7 +443,7 @@ class object_file_system_test extends tests\testcase {
         $filehash = $file->get_contenthash();
 
         // Delete file record so remove file will remove.
-        $DB->delete_records('files', array('contenthash' => $filehash));
+        $DB->delete_records('files', ['contenthash' => $filehash]);
         $this->filesystem->remove_file($filehash);
 
         $islocalreadable = $this->filesystem->is_file_readable_locally_by_hash($filehash);
@@ -456,7 +456,7 @@ class object_file_system_test extends tests\testcase {
         $filehash = $file->get_contenthash();
 
         // Delete file record so remove file will remove.
-        $DB->delete_records('files', array('contenthash' => $filehash));
+        $DB->delete_records('files', ['contenthash' => $filehash]);
         $this->filesystem->remove_file($filehash);
 
         $isremotereadable = $this->is_externally_readable_by_hash($filehash);
@@ -654,40 +654,40 @@ class object_file_system_test extends tests\testcase {
      * presigned_url_should_redirect_provider
      * @return array
      */
-    public function presigned_url_should_redirect_provider() {
-        $provider = array();
+    public static function presigned_url_should_redirect_provider(): array {
+        $provider = [];
 
         // Testing defaults.
-        $provider[] = array('Default', 'Default', false);
+        $provider[] = ['Default', 'Default', false];
 
         // Testing $enablepresignedurls.
-        $provider[] = array(1, 'Default', true);
-        $provider[] = array('1', 'Default', true);
-        $provider[] = array(0, 'Default', false);
-        $provider[] = array('0', 'Default', false);
-        $provider[] = array('', 'Default', false);
-        $provider[] = array(null, 'Default', false);
+        $provider[] = [1, 'Default', true];
+        $provider[] = ['1', 'Default', true];
+        $provider[] = [0, 'Default', false];
+        $provider[] = ['0', 'Default', false];
+        $provider[] = ['', 'Default', false];
+        $provider[] = [null, 'Default', false];
 
         // Testing $presignedminfilesize.
-        $provider[] = array(1, 0, true);
-        $provider[] = array(1, '0', true);
-        $provider[] = array(1, '', true);
+        $provider[] = [1, 0, true];
+        $provider[] = [1, '0', true];
+        $provider[] = [1, '', true];
 
         // Testing minimum file size to be greater than file size.
         // 12 is a size of the file with 'test content' content.
-        $provider[] = array(1, 13, false);
-        $provider[] = array(1, '13', false);
+        $provider[] = [1, 13, false];
+        $provider[] = [1, '13', false];
 
         // Testing minimum file size to be less than file size.
         // 12 is a size of the file with 'test content' content.
-        $provider[] = array(1, 11, true);
-        $provider[] = array(1, '11', true);
+        $provider[] = [1, 11, true];
+        $provider[] = [1, '11', true];
 
         // Testing nulls and empty strings.
-        $provider[] = array(null, null, false);
-        $provider[] = array(null, '', false);
-        $provider[] = array('', null, false);
-        $provider[] = array('', '', false);
+        $provider[] = [null, null, false];
+        $provider[] = [null, '', false];
+        $provider[] = ['', null, false];
+        $provider[] = ['', '', false];
 
         return $provider;
     }
@@ -733,7 +733,7 @@ class object_file_system_test extends tests\testcase {
      *
      * @return array
      */
-    public function get_expiration_time_method_if_supported_provider() {
+    public static function get_expiration_time_method_if_supported_provider(): array {
         $now = time();
 
         // Seconds after the minute from X.
@@ -840,7 +840,7 @@ class object_file_system_test extends tests\testcase {
      *
      * @return array
      */
-    public function get_valid_http_ranges_provider() {
+    public static function get_valid_http_ranges_provider(): array {
         return [
             ['', 0, false],
             ['bytes=0-', 100, (object)['rangefrom' => 0, 'rangeto' => 99, 'length' => 100]],
@@ -870,7 +870,7 @@ class object_file_system_test extends tests\testcase {
      *
      * @return array
      */
-    public function curl_range_request_to_presigned_url_provider() {
+    public static function curl_range_request_to_presigned_url_provider(): array {
         return [
             ['15-bytes string', (object)['rangefrom' => 0, 'rangeto' => 14, 'length' => 15], '15-bytes string'],
             ['15-bytes string', (object)['rangefrom' => 0, 'rangeto' => 9, 'length' => 10], '15-bytes s'],

--- a/tests/task/populate_objects_filesize_test.php
+++ b/tests/task/populate_objects_filesize_test.php
@@ -44,7 +44,7 @@ class populate_objects_filesize_test extends \tool_objectfs\tests\testcase {
             $this->create_local_file("Test 2")->get_contenthash(),
             $this->create_local_file("Test 3")->get_contenthash(),
             $this->create_local_file("Test 4")->get_contenthash(),
-            $this->create_local_file("This is a looong name")->get_contenthash()
+            $this->create_local_file("This is a looong name")->get_contenthash(),
         ];
 
         // Set all objects to have a filesize of null.
@@ -131,7 +131,7 @@ class populate_objects_filesize_test extends \tool_objectfs\tests\testcase {
             $this->create_local_file("Test 2")->get_contenthash(),
             $this->create_local_file("Test 3")->get_contenthash(),
             $this->create_local_file("Test 4")->get_contenthash(),
-            $this->create_local_file("This is a looong name")->get_contenthash()
+            $this->create_local_file("This is a looong name")->get_contenthash(),
         ];
 
         // Set all objects to have a filesize of null.

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2023051701;      // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 2023051701;      // Same as version.
-$plugin->requires  = 2023042400;      // Requires 4.2
+$plugin->requires  = 2023042400;      // Requires 4.2.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->supported = [402, 405];


### PR DESCRIPTION
**Changes**
- A port of https://github.com/catalyst/moodle-tool_objectfs/pull/620 to `MOODLE_402_STABLE` which fixes things with `phpcbf` as well as manually fixing unit test data providers
- Also copied over a commit made to 310 but not 402 - 00b514ffcc8da92ca8f1bb71624b382862a023f0 to fix phpdocs as well