### PR TITLE
Added support for AWS on Moodle 4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This plugin is GDPR complient if you enable the deletion of remote objects.
 2. Setup your remote object storage. See [Remote object storage setup](#amazon-s3)
 3. Clone this repository into admin/tool/objectfs
 4. Install one of the required SDK libraries for the storage file system that you will be using
-    1. Clone [moodle-local_aws](https://github.com/catalyst/moodle-local_aws) into local/aws for S3 or DigitalOcean Spaces or Google Cloud, or
+    1. AWS is included into Moodle 4.4, so no need to do anything for S3 or DigitalOcean Spaces or Google Cloud, or
     2. Clone [moodle-local_azure_storage](https://github.com/catalyst/moodle-local_azure_storage) into local/azure_storage for Azure Blob Storage, or
     3. Clone [moodle-local_openstack](https://github.com/matt-catalyst/moodle-local_openstack.git) into local/openstack for openstack(swift) storage
 5. Install the plugins through the moodle GUI.

--- a/classes/local/store/azure/stream_wrapper.php
+++ b/classes/local/store/azure/stream_wrapper.php
@@ -18,7 +18,7 @@
  * Azure Blob Storage stream wrapper to use "blob://<container>/<key>" files with PHP.
  *
  * Implementation references,
- * https://github.com/aws/aws-sdk-php/blob/master/src/S3/StreamWrapper.php
+ * @see \Aws\S3\StreamWrapper
  * https://phpazure.codeplex.com/SourceControl/latest#trunk/library/Microsoft/WindowsAzure/Storage/Blob/Stream.php
  *
  * @package    tool_objectfs

--- a/classes/local/store/digitalocean/client.php
+++ b/classes/local/store/digitalocean/client.php
@@ -39,7 +39,7 @@ class client extends s3_client {
      */
     public function __construct($config) {
         global $CFG;
-        $this->autoloader = $CFG->dirroot . '/local/aws/sdk/aws-autoloader.php';
+        $this->autoloader = $CFG->libdir . '/aws-sdk/src/functions.php';
         $this->testdelete = false;
 
         if ($this->get_availability() && !empty($config)) {

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -28,7 +28,7 @@ namespace tool_objectfs\local\store\s3;
 use tool_objectfs\local\manager;
 use tool_objectfs\local\store\object_client_base;
 use tool_objectfs\local\store\signed_url;
-use local_aws\admin_settings_aws_region;
+use core\aws\admin_settings_aws_region;
 
 define('AWS_API_VERSION', '2006-03-01');
 define('AWS_CAN_READ_OBJECT', 0);
@@ -43,7 +43,7 @@ class client extends object_client_base {
     /**
      * @var int A predefined limit of data stored.
      * When hit, php://temp will use a temporary file.
-     * Reference: https://github.com/catalyst/moodle-local_aws/blob/master/sdk/Aws/S3/StreamWrapper.php#L19-L25
+     * Reference: line 19-25 of @see \Aws\S3\StreamWrapper
      */
     const MAX_TEMP_LIMIT = 2097152;
 
@@ -69,7 +69,7 @@ class client extends object_client_base {
      */
     public function __construct($config) {
         global $CFG;
-        $this->autoloader = $CFG->dirroot . '/local/aws/sdk/aws-autoloader.php';
+        $this->autoloader = $CFG->libdir . '/aws-sdk/src/functions.php';
         $this->config = $config;
 
         if ($this->get_availability() && !empty($config)) {
@@ -431,27 +431,6 @@ class client extends object_client_base {
      * @throws \coding_exception
      */
     public function define_client_section($settings, $config) {
-        global $OUTPUT;
-        $plugins = \core_component::get_plugin_list('local');
-
-        if (!array_key_exists('aws', $plugins)) {
-            $text  = $OUTPUT->notification(new \lang_string('settings:aws:installneeded', OBJECTFS_PLUGIN_NAME));
-            $settings->add(new \admin_setting_heading('tool_objectfs/aws',
-                new \lang_string('settings:aws:header', 'tool_objectfs'), $text));
-            return $settings;
-        }
-
-        $plugin = (object)['version' => null];
-        if (file_exists($plugins['aws'].'/version.php')) {
-            include($plugins['aws'].'/version.php');
-        }
-        if (empty($plugin->version) || $plugin->version < 2020051200) {
-            $text  = $OUTPUT->notification(new \lang_string('settings:aws:upgradeneeded', OBJECTFS_PLUGIN_NAME));
-            $settings->add(new \admin_setting_heading('tool_objectfs/aws',
-                new \lang_string('settings:aws:header', 'tool_objectfs'), $text));
-            return $settings;
-        }
-
         $settings->add(new \admin_setting_heading('tool_objectfs/aws',
             new \lang_string('settings:aws:header', 'tool_objectfs'), $this->define_client_check()));
 

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -120,8 +120,6 @@ $string['settings:aws:region'] = 'region';
 $string['settings:aws:region_help'] = 'Amazon S3 API gateway region.';
 $string['settings:aws:base_url'] = 'Base URL';
 $string['settings:aws:base_url_help'] = 'Alternate url for cnames or s3 compatible endpoints. Leave blank for normal S3 use.';
-$string['settings:aws:upgradeneeded'] = 'Please upgrade \'local_aws\' plugin to the latest supported version.';
-$string['settings:aws:installneeded'] = 'Please install \'local_aws\' plugin.';
 $string['settings:aws:usesdkcreds'] = 'Use the default credential provider chain to find AWS credentials';
 $string['settings:aws:sdkcredsok'] = 'AWS credentials found. This setting can be safely enabled.';
 $string['settings:aws:sdkcredserror'] = 'Couldn\'t find AWS credentials. It\'s unsafe to enable this setting. Follow up <a href="https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html">AWS documentation</a>.';

--- a/version.php
+++ b/version.php
@@ -25,9 +25,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+/** @var object $plugin */
+$plugin->component = "tool_objectfs";
 $plugin->version   = 2023051701;      // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 2023051701;      // Same as version.
-$plugin->requires  = 2023042400;      // Requires 4.2.
-$plugin->component = "tool_objectfs";
+$plugin->requires  = 2024042200;      // Requires 4.4.
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->supported = [402, 405];


### PR DESCRIPTION
There was no MOODLE_404_STABLE branch, so i just chose the 4.2 one. A seperate branch should be created though

see: https://github.com/catalyst/moodle-tool_objectfs/issues/613