### PR TITLE
Add token expiry check

### DIFF
--- a/classes/check/token_expiry.php
+++ b/classes/check/token_expiry.php
@@ -1,0 +1,71 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\check;
+
+use core\check\check;
+use core\check\result;
+
+/**
+ * Token expiry check.
+ *
+ * @package    tool_objectfs
+ * @author     Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright  Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class token_expiry extends check {
+    /**
+     * Checks the token expiry time against thresholds
+     * @return result
+     */
+    public function get_result(): result {
+        $config = \tool_objectfs\local\manager::get_objectfs_config();
+        $client = \tool_objectfs\local\manager::get_client($config);
+
+        // No client set - n/a.
+        if (empty($client)) {
+            return new result(result::NA, get_string('check:tokenexpiry:na', 'tool_objectfs'));
+        }
+
+        $expirytime = $client->get_token_expiry_time();
+        $secondsleft = $expirytime - time();
+
+        $strparams = [
+            'dayssince' => abs(round($secondsleft / DAYSECS)),
+            'time' => userdate($expirytime),
+        ];
+
+        // Not implemented or token not set - n/a.
+        if ($expirytime == -1) {
+            return new result(result::NA, get_string('check:tokenexpiry:na', 'tool_objectfs'));
+        }
+
+        // Is in past - token has expired.
+        if ($secondsleft < 0) {
+            return new result(result::CRITICAL, get_string('check:tokenexpiry:expired', 'tool_objectfs', $strparams));
+        }
+
+        // Is in warning period - warn.
+        $warnthreshold = (int) $config->tokenexpirywarnperiod;
+        if ($secondsleft < $warnthreshold) {
+            return new result(result::WARNING, get_string('check:tokenexpiry:expiresin', 'tool_objectfs', $strparams));
+        }
+
+        // Else ok.
+        return new result(result::OK, get_string('check:tokenexpiry:expiresin', 'tool_objectfs', $strparams));
+    }
+}

--- a/classes/local/manager.php
+++ b/classes/local/manager.php
@@ -329,6 +329,10 @@ class manager {
      * @return string
      */
     public static function get_client_classname_from_fs($filesystem) {
+        // Unit tests need to return the test client.
+        if ($filesystem == '\tool_objectfs\tests\test_file_system') {
+            return '\tool_objectfs\tests\test_client';
+        }
         $clientclass = str_replace('_file_system', '', $filesystem);
         return str_replace('tool_objectfs\\', 'tool_objectfs\\local\\store\\', $clientclass.'\\client');
     }

--- a/classes/local/object_manipulator/candidates/manipulator_candidates.php
+++ b/classes/local/object_manipulator/candidates/manipulator_candidates.php
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_objectfs\local\object_manipulator\candidates;
+
+use dml_exception;
+
 /**
  * Interface manipulator_candidates
  * @package tool_objectfs
@@ -21,11 +25,6 @@
  * @copyright Catalyst IT
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace tool_objectfs\local\object_manipulator\candidates;
-
-use dml_exception;
-
 interface manipulator_candidates {
 
     /**

--- a/classes/local/object_manipulator/object_manipulator.php
+++ b/classes/local/object_manipulator/object_manipulator.php
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_objectfs\local\object_manipulator;
+
+use stdClass;
+
 /**
  * Object manipulator interface class.
  *
@@ -22,11 +26,6 @@
  * @copyright Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace tool_objectfs\local\object_manipulator;
-
-use stdClass;
-
 interface object_manipulator {
 
 

--- a/classes/local/store/object_client.php
+++ b/classes/local/store/object_client.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_objectfs\local\store;
+
 /**
  * Objectfs client interface.
  *
@@ -22,11 +24,7 @@
  * @copyright Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace tool_objectfs\local\store;
-
 interface object_client {
-
     /**
      * construct
      * @param \stdClass $config

--- a/classes/local/store/object_client.php
+++ b/classes/local/store/object_client.php
@@ -137,6 +137,12 @@ interface object_client {
      */
     public function test_range_request($filesystem);
 
+    /**
+     * Get the expiry time of the token used for this fs.
+     * returns -1 if not implemented, or no token is set.
+     * @return int unix timestamp the token set expires at
+     */
+    public function get_token_expiry_time(): int;
 }
 
 

--- a/classes/local/store/object_client_base.php
+++ b/classes/local/store/object_client_base.php
@@ -187,4 +187,13 @@ abstract class object_client_base implements object_client {
     public function test_permissions($testdelete) {
         return (object)['success' => false, 'details' => ''];
     }
+
+    /**
+     * Return expiry time of token, default is -1 meaning not implemented/enabled.
+     * @return int
+     */
+    public function get_token_expiry_time(): int {
+        // Returning -1 = not implemented.
+        return -1;
+    }
 }

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Privacy provider.
  *

--- a/classes/task/objectfs_task.php
+++ b/classes/task/objectfs_task.php
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_objectfs\task;
+
 /**
  * Base abstract class for objectfs tasks.
  *
@@ -22,9 +24,6 @@
  * @copyright Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace tool_objectfs\task;
-
 interface objectfs_task {
 
     /**

--- a/classes/tests/test_azure_integration_client.php
+++ b/classes/tests/test_azure_integration_client.php
@@ -19,8 +19,11 @@ namespace tool_objectfs\tests;
 use tool_objectfs\local\store\azure\client;
 
 /**
- * [Description test_azure_integration_client]
- * @package tool_objectfs
+ * Client used for integration testing azure client
+ *
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class test_azure_integration_client extends client {
 

--- a/classes/tests/test_azure_integration_client.php
+++ b/classes/tests/test_azure_integration_client.php
@@ -38,7 +38,10 @@ class test_azure_integration_client extends client {
      * @return void
      */
     public function __construct($config) {
-        parent::__construct($config);
+        // Set config directly. Calling __construct will do nothing
+        // since unit tests do not have the azure sdk installed.
+        $this->config = $config;
+
         $time = microtime();
         $this->runidentifier = md5($time);
     }

--- a/classes/tests/test_client.php
+++ b/classes/tests/test_client.php
@@ -19,8 +19,11 @@ namespace tool_objectfs\tests;
 use tool_objectfs\local\store\object_client_base;
 
 /**
- * [Description test_client]
- * @package tool_objectfs
+ * Test client for PHP unit tests
+ *
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class test_client extends object_client_base {
     /**

--- a/classes/tests/test_client.php
+++ b/classes/tests/test_client.php
@@ -157,5 +157,14 @@ class test_client extends object_client_base {
     public function get_maximum_upload_size() {
         return $this->maxupload;
     }
+
+    /**
+     * Returns test expiry time.
+     * @return int
+     */
+    public function get_token_expiry_time(): int {
+        global $CFG;
+        return $CFG->objectfs_phpunit_token_expiry_time;
+    }
 }
 

--- a/classes/tests/test_digitalocean_integration_client.php
+++ b/classes/tests/test_digitalocean_integration_client.php
@@ -19,8 +19,11 @@ namespace tool_objectfs\tests;
 use tool_objectfs\local\store\digitalocean\client;
 
 /**
- * [Description test_digitalocean_integration_client]
- * @package tool_objectfs
+ * Client used for integration testing digitalocean client
+ *
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class test_digitalocean_integration_client extends client {
 

--- a/classes/tests/test_s3_integration_client.php
+++ b/classes/tests/test_s3_integration_client.php
@@ -19,8 +19,11 @@ namespace tool_objectfs\tests;
 use tool_objectfs\local\store\s3\client;
 
 /**
- * [Description test_s3_integration_client]
- * @package tool_objectfs
+ * Client used for integration testing aws client
+ *
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class test_s3_integration_client extends client {
 

--- a/classes/tests/test_swift_integration_client.php
+++ b/classes/tests/test_swift_integration_client.php
@@ -19,8 +19,11 @@ namespace tool_objectfs\tests;
 use tool_objectfs\local\store\swift\client;
 
 /**
- * [Description test_swift_integration_client]
- * @package tool_objectfs
+ * Client used for integration testing swift client
+ *
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class test_swift_integration_client extends client {
 

--- a/classes/tests/testcase.php
+++ b/classes/tests/testcase.php
@@ -26,8 +26,11 @@ use tool_objectfs\local\store\object_file_system;
 use tool_objectfs\local\store\signed_url;
 
 /**
- * [Description testcase]
- * @package tool_objectfs
+ * Testcase with useful / shared methods for common objectfs tests.
+ *
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 abstract class testcase extends \advanced_testcase {
 

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -269,3 +269,9 @@ $string['backportfiletypesclass'] = 'Backport MDL-53240 is missing. Follow up ht
 
 $string['check:proxyrangerequestsdisabled'] = 'The proxy range request setting is disabled.';
 $string['checkproxy_range_request'] = 'Pre-signed URL range request proxy';
+
+$string['checktoken_expiry'] = 'Token expiry';
+$string['check:tokenexpiry:expiresin'] = 'Token expires in {$a->dayssince} days on {$a->time}';
+$string['check:tokenexpiry:expired'] = 'Token expired for {$a->dayssince} days. Expired on {$a->time}';
+$string['check:tokenexpiry:na'] = 'Token expired not implemented for filesystem, or no token is set';
+$string['settings:tokenexpirywarnperiod'] = 'Token expiry warn period';

--- a/lib.php
+++ b/lib.php
@@ -120,11 +120,13 @@ function tool_objectfs_pluginfile($course, $cm, context $context, $filearea, arr
  * @return array
  */
 function tool_objectfs_status_checks() {
+    $checks = [
+        new tool_objectfs\check\token_expiry(),
+    ];
+
     if (get_config('tool_objectfs', 'proxyrangerequests')) {
-        return [
-            new tool_objectfs\check\proxy_range_request(),
-        ];
+        $checks[] = new tool_objectfs\check\proxy_range_request();
     }
 
-    return [];
+    return $checks;
 }

--- a/settings.php
+++ b/settings.php
@@ -106,6 +106,10 @@ if ($ADMIN->fulltree) {
         new lang_string('settings:useproxy_help', 'tool_objectfs'),
         0));
 
+    $settings->add(new admin_setting_configduration('tool_objectfs/tokenexpirywarnperiod',
+        new lang_string('settings:tokenexpirywarnperiod', 'tool_objectfs'),
+        '', 60 * DAYSECS, DAYSECS));
+
     $settings->add(new admin_setting_heading('tool_objectfs/filetransfersettings',
         new lang_string('settings:filetransferheader', 'tool_objectfs'), ''));
 

--- a/tests/local/object_manipulator/checker_test.php
+++ b/tests/local/object_manipulator/checker_test.php
@@ -22,7 +22,9 @@ use tool_objectfs\local\manager;
  * Tests for object checker.
  *
  * @covers \tool_objectfs\local\object_manipulator\checker
- * @package tool_objectfs
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class checker_test extends \tool_objectfs\tests\testcase {
 

--- a/tests/local/object_manipulator/deleter_test.php
+++ b/tests/local/object_manipulator/deleter_test.php
@@ -22,7 +22,9 @@ use tool_objectfs\local\manager;
  * Tests for object deleter.
  *
  * @covers \tool_objectfs\local\object_manipulator\deleter
- * @package tool_objectfs
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class deleter_test extends \tool_objectfs\tests\testcase {
 

--- a/tests/local/object_manipulator/orphaner_test.php
+++ b/tests/local/object_manipulator/orphaner_test.php
@@ -23,7 +23,9 @@ use tool_objectfs\local\object_manipulator\candidates\candidates_finder;
  * Tests for object orphaner.
  *
  * @covers \tool_objectfs\local\object_manipulator\orphaner
- * @package tool_objectfs
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class orphaner_test extends \tool_objectfs\tests\testcase {
 

--- a/tests/local/object_manipulator/puller_test.php
+++ b/tests/local/object_manipulator/puller_test.php
@@ -22,7 +22,9 @@ use tool_objectfs\local\manager;
  * Tests for object puller.
  *
  * @covers \tool_objectfs\local\object_manipulator\puller
- * @package tool_objectfs
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class puller_test extends \tool_objectfs\tests\testcase {
 

--- a/tests/local/object_manipulator/pusher_test.php
+++ b/tests/local/object_manipulator/pusher_test.php
@@ -23,7 +23,9 @@ use tool_objectfs\local\object_manipulator\candidates\candidates_finder;
  * Tests for object pusher.
  *
  * @covers \tool_objectfs\local\object_manipulator\pusher
- * @package tool_objectfs
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class pusher_test extends \tool_objectfs\tests\testcase {
 

--- a/tests/local/object_manipulator/recoverer_test.php
+++ b/tests/local/object_manipulator/recoverer_test.php
@@ -23,7 +23,9 @@ use tool_objectfs\local\object_manipulator\candidates\candidates_finder;
  * Tests for object recoverer.
  *
  * @covers \tool_objectfs\local\object_manipulator\recoverer
- * @package tool_objectfs
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class recoverer_test extends \tool_objectfs\tests\testcase {
 

--- a/tests/local/tasks_test.php
+++ b/tests/local/tasks_test.php
@@ -20,7 +20,9 @@ namespace tool_objectfs\local;
  * End to end tests for tasks. Make sure all the plumbing is ok.
  *
  * @covers \tool_objectfs\local\manager
- * @package tool_objectfs
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tasks_test extends \tool_objectfs\tests\testcase {
 

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -24,7 +24,9 @@ use tool_objectfs\tests\test_file_system;
  * Test basic operations of object file system.
  *
  * @covers \tool_objectfs\local\store\object_file_system
- * @package tool_objectfs
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class object_file_system_test extends tests\testcase {
 

--- a/tests/token_expiry_test.php
+++ b/tests/token_expiry_test.php
@@ -1,0 +1,77 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs;
+
+use core\check\result;
+use tool_objectfs\check\token_expiry;
+use tool_objectfs\local\manager;
+use tool_objectfs\tests\testcase;
+
+/**
+ * Token expiry check test.
+ *
+ * @covers \tool_objectfs\check\token_expiry
+ * @package   tool_objectfs
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class token_expiry_test extends testcase {
+    /**
+     * Provides to test_get_result
+     * @return array
+     */
+    public static function get_result_provider(): array {
+        return [
+            'ok' => [
+                'expiry' => time() + 10 * DAYSECS,
+                'warnperiod' => 5 * DAYSECS,
+                'expectedresult' => result::OK,
+            ],
+            'warning' => [
+                'expiry' => time() + DAYSECS,
+                'warnperiod' => 5 * DAYSECS,
+                'expectedresult' => result::WARNING,
+            ],
+            'expired' => [
+                'expiry' => time() - DAYSECS,
+                'warnperiod' => 5 * DAYSECS,
+                'expectedresult' => result::CRITICAL,
+            ],
+        ];
+    }
+
+    /**
+     * Tests getting check result
+     * @param int $expirytime time to use as the tokens expiry
+     * @param int $warnperiod period to set for warning about token expiry
+     * @param string $expectedresult one of the result:: constants that is expected to be returned.
+     * @dataProvider get_result_provider
+     */
+    public function test_get_result(int $expirytime, int $warnperiod, string $expectedresult) {
+        global $CFG;
+        $config = manager::get_objectfs_config();
+        $config->filesystem = '\\tool_objectfs\\tests\\test_file_system';
+        manager::set_objectfs_config($config);
+
+        $CFG->objectfs_phpunit_token_expiry_time = $expirytime;
+        set_config('tokenexpirywarnperiod', $warnperiod, 'tool_objectfs');
+
+        $check = new token_expiry();
+        $result = $check->get_result();
+        $this->assertEquals($expectedresult, $result->get_status());
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023051701;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2023051701;      // Same as version.
+$plugin->version   = 2023051702;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2023051702;      // Same as version.
 $plugin->requires  = 2020110900;      // Requires Filesystem API.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
**Changes**
- Exposes a new method for clients to implement `get_token_expiry_time`, implemented only for Azure client atm
- This is read by a check class and outputs OK, WARNING, ERROR based on the time of the expiry.
- Fixup codestandards / pass ci

**Testing**
- Covered by unit tests

**Cherry picks**
- To MOODLE_402_STABLE branch: https://github.com/catalyst/moodle-tool_objectfs/pull/636