### PR TITLE
bugfix: fix token expiry check in admin settings

### DIFF
--- a/classes/check/token_expiry.php
+++ b/classes/check/token_expiry.php
@@ -29,6 +29,16 @@ use core\check\result;
  */
 class token_expiry extends check {
     /**
+     * Link to ObjectFS settings page.
+     *
+     * @return \action_link|null
+     */
+    public function get_action_link(): ?\action_link {
+        $url = new \moodle_url('/admin/category.php', ['category' => 'tool_objectfs']);
+        return new \action_link($url, get_string('pluginname', 'tool_objectfs'));
+    }
+
+    /**
      * Checks the token expiry time against thresholds
      * @return result
      */

--- a/classes/local/store/azure/client.php
+++ b/classes/local/store/azure/client.php
@@ -25,10 +25,8 @@
 
 namespace tool_objectfs\local\store\azure;
 
-use admin_setting_description;
 use SimpleXMLElement;
 use stdClass;
-use tool_objectfs\check\token_expiry;
 use tool_objectfs\local\store\azure\stream_wrapper;
 use tool_objectfs\local\store\object_client_base;
 
@@ -361,15 +359,6 @@ class client extends object_client_base {
         $settings->add(new \admin_setting_configpasswordunmask('tool_objectfs/azure_sastoken',
             new \lang_string('settings:azure:sastoken', 'tool_objectfs'),
             new \lang_string('settings:azure:sastoken_help', 'tool_objectfs'), ''));
-
-        // Admin_setting_check only exists in 4.5+, in lower versions fallback to a basic description.
-        if (class_exists('admin_setting_check')) {
-            $settings->add(new admin_setting_check('tool_objectfs/check_tokenexpiry', new token_expiry(), true));
-        } else {
-            $summary = (new token_expiry())->get_result()->get_summary();
-            $settings->add(new admin_setting_description('tool_objectfs/tokenexpirycheckresult',
-                get_string('checktoken_expiry', 'tool_objectfs'), $summary));
-        }
 
         return $settings;
     }

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -262,6 +262,8 @@ $string['settings:handlernotset'] = '$CFG->alternative_file_system_class is not 
 $string['settings:testingheader'] = 'Test Settings';
 $string['settings:testingdescr'] = 'This setting is mainly for testing purposes and introduces overhead to check the location.';
 
+$string['settings:checksheader'] = 'Checks';
+
 $string['settings:error:numeric'] = 'Please enter a number which is greater than or equal 0.';
 $string['settings:notconfigured'] = 'Missing configuration.';
 $string['total_deleted_dirs'] = 'Total number of deleted directories: ';
@@ -273,5 +275,5 @@ $string['checkproxy_range_request'] = 'Pre-signed URL range request proxy';
 $string['checktoken_expiry'] = 'Token expiry';
 $string['check:tokenexpiry:expiresin'] = 'Token expires in {$a->dayssince} days on {$a->time}';
 $string['check:tokenexpiry:expired'] = 'Token expired for {$a->dayssince} days. Expired on {$a->time}';
-$string['check:tokenexpiry:na'] = 'Token expired not implemented for filesystem, or no token is set';
+$string['check:tokenexpiry:na'] = 'Token expiry check not implemented for filesystem, or no token is set';
 $string['settings:tokenexpirywarnperiod'] = 'Token expiry warn period';

--- a/settings.php
+++ b/settings.php
@@ -23,6 +23,8 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use tool_objectfs\check\token_expiry;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once(__DIR__ . '/classes/local/manager.php');
@@ -246,6 +248,18 @@ if ($ADMIN->fulltree) {
                 );
             }
         }
+    }
+
+    $settings->add(new admin_setting_heading('tool_objectfs/checks',
+        new lang_string('settings:checksheader', 'tool_objectfs'), ''));
+
+    // Admin_setting_check only exists in 4.5+, in lower versions fallback to a basic description.
+    if (class_exists('admin_setting_check')) {
+        $settings->add(new admin_setting_check('tool_objectfs/check_tokenexpiry', new token_expiry(), true));
+    } else {
+        $summary = (new token_expiry())->get_result()->get_summary();
+        $settings->add(new admin_setting_description('tool_objectfs/tokenexpirycheckresult',
+            get_string('checktoken_expiry', 'tool_objectfs'), $summary));
     }
 
     $settings->add(new admin_setting_heading('tool_objectfs/testsettings',

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091700;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024091700;      // Same as version.
+$plugin->version   = 2024102400;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2024102400;      // Same as version.
 $plugin->requires  = 2023042400;      // Requires 4.2.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
**Issue:**
There were a few issues found after more thorough testing of  https://github.com/catalyst/moodle-tool_objectfs/pull/636:
1. The class wasn't included (oops!)
2. There is a core bug which means on newer php versions if it didn't have an action link it would throw an exception -> https://tracker.moodle.org/browse/MDL-83537
3. The admin_setting_check doesn't work unless it is in the top level settings page and not in the client settings definition area, because of the way internally it searches through the admin tree to find the check.

**Fixes:**
1. Moved token expiry check to top level. Realistically all client sdks could/should implement this so no point having it only in the Azure client section.
2. Added action link as an fix until MDL-83537 is implemented
3. Fixed a spelling error

**Testing/screenshots:**
Where token expiry is implemented - in Azure client code:
![2024-10-24_10-20](https://github.com/user-attachments/assets/42edaa55-3478-43dd-b067-6fb72a96ecef)

Where token expiry is not implemented:
![2024-10-24_10-21](https://github.com/user-attachments/assets/81f938c5-2104-4550-ab3d-2d5958cec345)

