### PR TITLE
Updated Azure storage compatibility

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,17 @@
+# Migration guides
+
+## Migrating from local_azure_storage to local_azureblobstorage
+
+Since March 2024, Microsoft officially discontinued support for the PHP SDK for Azure storage. This means the `local_azure_storage` plugin which is a wrapper of the SDK will no longer be updated, and is already out of date with newer php versions.
+
+The plugin `local_azureblobstorage` was created to replace this, with a simpler and cleaner API for interacting with the Azure blob storage service via REST APIs. Objectfs has been updated with a new client handler class to enable you to cut over to the new storage system as easily as possible.
+
+This new library is only supported in higher PHP versions.
+
+### Steps
+1. If you are on Moodle 4.2, ensure you have updated the previous `local_azure_storage` to the `MOODLE_42_STABLE` branch. This fixes some fatal errors caused by Guzzle namespace conflicts.
+2. Install `local_azureblobstorage` https://github.com/catalyst/moodle-local_azureblobstorage
+3. In the objectfs settings, change the `filesystem` config variable to `\tool_objectfs\azure_blob_storage_file_system` and save. ObjectFS will now be using the new API to communicate with Azure. You do not need to enter new credentials, the credentials are shared with the old client.
+4. Test and ensure the site works as expected.
+5. If you encounter any issues and wish to revert back, simply change the `filesystem` configuration back to the old client. This will immediately begin to use the old libraries again.
+6. Once you are happy, simply uninstall the `local_azure_storage` plugin. The migration is now complete.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ az storage container policy create \
     --name <policy_name> \
     --start <YYYY-MM-DD> \
     --expiry <YYYY-MM-DD> \
-    --permissions rw
+    --permissions racwl
+    // Or optionally to allow delete
+    --permissions racwld
 
 # Start and Expiry are optional arguments.
 ```

--- a/README.md
+++ b/README.md
@@ -5,31 +5,45 @@
 # moodle-tool_objectfs
 
 A remote object storage file system for Moodle. Intended to provide a plug-in that can be installed and configured to work with any supported remote object storage solution.
-* [Use cases](#use-cases)
-  * [Offloading large and old files to save money](#offloading-large-and-old-files-to-save-money)
-  * [Sharing files across moodles to save disk](#sharing-files-across-moodles-to-save-disk)
-  * [Sharing files across environments to save time](#sharing-files-across-environments-to-save-time)
-  * [Sharing files with data washed environments](#sharing-files-with-data-washed-environments)
-* [Installation](#installation)
-* [Compatible object stores](#compatible-object-stores)
-  * [Amazon S3](#amazon-s3)
-  * [Minio.io S3](#minio-s3)
-  * [Google gcs](#google-gcs)
-  * [Azure Blob Storage](#azure-blob-storage)
-  * [DigitalOcean Spaces](#digitalocean-spaces)
-  * [Openstack Object Storage](#openstack-object-storage)
-* [Moodle configuration](#moodle-configuration)
-  * [General Settings](#general-settings)
-  * [File Transfer settings](#file-transfer-settings)
-  * [Pre-Signed URLs Settings](#pre-signed-urls-settings)
-  * [Amazon S3 settings](#amazon-s3-settings)
-  * [Minio.io S3 settings](#minio-s3-settings)
-  * [Azure Blob Storage settings](#azure-blob-storage-settings)
-  * [DigitalOcean Spaces settings](#digitalocean-spaces-settings)
-* [Integration testing](#integration-testing)
-* [Applying core patches](#applying-core-patches)
-* [Crafted by Catalyst IT](#crafted-by-catalyst-it)
-* [Contributing and support](#contributing-and-support)
+- [moodle-tool\_objectfs](#moodle-tool_objectfs)
+  - [Use cases](#use-cases)
+    - [Offloading large and old files to save money](#offloading-large-and-old-files-to-save-money)
+    - [Sharing files across moodles to save disk](#sharing-files-across-moodles-to-save-disk)
+    - [Sharing files across environments to save time](#sharing-files-across-environments-to-save-time)
+    - [Sharing files with data washed environments](#sharing-files-with-data-washed-environments)
+  - [GDPR](#gdpr)
+  - [Branches](#branches)
+  - [Installation](#installation)
+  - [Compatible object stores](#compatible-object-stores)
+    - [Amazon S3](#amazon-s3)
+    - [Minio S3](#minio-s3)
+    - [Google GCS](#google-gcs)
+    - [Azure Blob Storage](#azure-blob-storage)
+    - [DigitalOcean Spaces](#digitalocean-spaces)
+    - [Openstack Object Storage](#openstack-object-storage)
+  - [Moodle configuration](#moodle-configuration)
+    - [General Settings](#general-settings)
+    - [File Transfer settings](#file-transfer-settings)
+    - [File System settings](#file-system-settings)
+    - [Pre-Signed URLs Settings](#pre-signed-urls-settings)
+    - [Amazon S3 settings](#amazon-s3-settings)
+    - [Minio S3 settings](#minio-s3-settings)
+    - [Azure Blob Storage settings](#azure-blob-storage-settings)
+    - [DigitalOcean Spaces settings](#digitalocean-spaces-settings)
+    - [Openstack Object Storage settings](#openstack-object-storage-settings)
+  - [Integration testing](#integration-testing)
+  - [Applying core patches](#applying-core-patches)
+      - [Moodle 3.9:](#moodle-39)
+      - [Moodle 3.8:](#moodle-38)
+      - [Moodle 3.4 - 3.7:](#moodle-34---37)
+      - [Moodle 3.3 and Totara 12:](#moodle-33-and-totara-12)
+      - [Moodle 3.2 and Totara 11:](#moodle-32-and-totara-11)
+      - [Moodle 2.9 - 3.1 and Totara 2.9, 9 - 10:](#moodle-29---31-and-totara-29-9---10)
+      - [Moodle 2.7 - 2.8 and Totara 2.7 - 2.8:](#moodle-27---28-and-totara-27---28)
+    - [PHPUnit test compatibility](#phpunit-test-compatibility)
+  - [Contributing and support](#contributing-and-support)
+  - [Warm thanks](#warm-thanks)
+  - [Crafted by Catalyst IT](#crafted-by-catalyst-it)
 
 ## Use cases
 There are a number of different ways you can use this plug in. See [Recommended use case settings](#recommended-use-case-settings) for recommended settings for each one.
@@ -75,7 +89,7 @@ This plugin is GDPR complient if you enable the deletion of remote objects.
 3. Clone this repository into admin/tool/objectfs
 4. Install one of the required SDK libraries for the storage file system that you will be using
     1. Clone [moodle-local_aws](https://github.com/catalyst/moodle-local_aws) into local/aws for S3 or DigitalOcean Spaces or Google Cloud, or
-    2. Clone [moodle-local_azure_storage](https://github.com/catalyst/moodle-local_azure_storage) into local/azure_storage for Azure Blob Storage, or
+    2. Clone [moodle-local_azureblobstorage](https://github.com/catalyst/moodle-local_azureblobstorage) into local/azureblobstorage for Azure Blob Storage, or
     3. Clone [moodle-local_openstack](https://github.com/matt-catalyst/moodle-local_openstack.git) into local/openstack for openstack(swift) storage
 5. Install the plugins through the moodle GUI.
 6. Configure the plugin. See [Moodle configuration](#moodle-configuration)
@@ -88,7 +102,7 @@ $CFG->alternative_file_system_class = '\tool_objectfs\s3_file_system';
 
 * Azure Blob Storage
 ```php
-$CFG->alternative_file_system_class = '\tool_objectfs\azure_file_system';
+$CFG->alternative_file_system_class = '\tool_objectfs\azure_blob_storage_file_system';
 ```
 
 * DigitalOcean Spaces
@@ -154,6 +168,10 @@ Setup for Minio.io bucket can be found on there website [here](https://min.io)
 - You will need to set 'base_url' to https://storage.googleapis.com in your config
 
 ### Azure Blob Storage
+
+*Migration from previous API (Moodle 4.2+)*
+
+[Migration guide from local_azure_storage to local_azureblobstorage](MIGRATION#migrating-from-localazurestorage-to-localazureblobstorage)
 
 *Azure Storage container guide with the CLI*
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -15,13 +15,21 @@ $CFG->phpunit_objectfs_s3_integration_test_credentials = array(
     's3_region' => 'Your region',
 );
 ```
-* Azure:
+* Azure (deprecated API):
 ```php
 $CFG->phpunit_objectfs_azure_integration_test_credentials = array(
     'azure_accountname' => 'Your account name',
     'azure_container' => 'Your container',
     'azure_sastoken' => 'Your sas token',
 );
+```
+* Azure Blob Storage:
+```php
+$CFG->phpunit_objectfs_azure_blob_storage_integration_test_credentials = [
+    'azure_accountname' => 'Your account name',
+    'azure_container' => 'Your container',
+    'azure_sastoken' => 'Your sas token',
+];
 ```
 * Swift:
 ```php

--- a/classes/azure_blob_storage_file_system.php
+++ b/classes/azure_blob_storage_file_system.php
@@ -14,37 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace tool_objectfs;
+
+use tool_objectfs\local\store\azure_blob_storage\file_system;
+
 /**
  * File system for Azure Blob Storage.
  *
+ * This file tells objectfs that this storage system is available for use.
+ * E.g. via $CFG->alternative_file_system_class
+ *
  * @package    tool_objectfs
- * @author     Nicholas Hoobin <nicholashoobin@catalyst-au.net>
+ * @author     Matthew Hilton <matthewhilton@catalyst-au.net>
  * @copyright  Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
-namespace tool_objectfs\local\store\azure;
-
-defined('MOODLE_INTERNAL') || die();
-
-use tool_objectfs\local\store\object_file_system;
-
-require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
-
-/**
- * file_system
- * @deprecated Since Moodle 4.2 - Please see the README about updating to new azure_blob_storage client.
- */
-class file_system extends object_file_system {
-
-    /**
-     * initialise_external_client
-     * @param mixed $config
-     *
-     * @return client
-     */
-    protected function initialise_external_client($config) {
-        $asclient = new client($config);
-        return $asclient;
-    }
+class azure_blob_storage_file_system extends file_system {
 }

--- a/classes/local/manager.php
+++ b/classes/local/manager.php
@@ -306,17 +306,18 @@ class manager {
     public static function get_available_fs_list() {
         $result[''] = get_string('pleaseselect', OBJECTFS_PLUGIN_NAME);
 
-        $filesystems['\tool_objectfs\azure_file_system'] = '\tool_objectfs\azure_file_system';
+        $filesystems['\tool_objectfs\azure_file_system'] = '\tool_objectfs\azure_file_system [DEPRECATED]';
         $filesystems['\tool_objectfs\digitalocean_file_system'] = '\tool_objectfs\digitalocean_file_system';
         $filesystems['\tool_objectfs\s3_file_system'] = '\tool_objectfs\s3_file_system';
         $filesystems['\tool_objectfs\swift_file_system'] = '\tool_objectfs\swift_file_system';
+        $filesystems['\tool_objectfs\azure_blob_storage_file_system'] = '\tool_objectfs\azure_blob_storage_file_system';
 
-        foreach ($filesystems as $filesystem) {
+        foreach ($filesystems as $filesystem => $name) {
             $clientclass = self::get_client_classname_from_fs($filesystem);
             $client = new $clientclass(null);
 
             if ($client && $client->get_availability()) {
-                $result[$filesystem] = $filesystem;
+                $result[$filesystem] = $name;
             }
         }
         return $result;

--- a/classes/local/store/azure/client.php
+++ b/classes/local/store/azure/client.php
@@ -32,6 +32,7 @@ use tool_objectfs\local\store\object_client_base;
 
 /**
  * client
+ * @deprecated Since Moodle 4.2 - Please see the README about updating to new azure_blob_storage client.
  */
 class client extends object_client_base {
 

--- a/classes/local/store/azure/stream_wrapper.php
+++ b/classes/local/store/azure/stream_wrapper.php
@@ -44,6 +44,7 @@ use Psr\Http\Message\StreamInterface;
 
 /**
  * stream_wrapper
+ * @deprecated Since Moodle 4.2 - Please see the README about updating to new azure_blob_storage client.
  */
 class stream_wrapper {
 

--- a/classes/local/store/azure_blob_storage/client.php
+++ b/classes/local/store/azure_blob_storage/client.php
@@ -92,7 +92,7 @@ class client extends object_client_base {
      */
     public function get_fullpath_from_hash($contenthash): string {
         $filepath = $this->get_filepath_from_hash($contenthash);
-        return "blob://$filepath";
+        return "azure://$filepath";
     }
 
     /**
@@ -113,7 +113,7 @@ class client extends object_client_base {
      * @return string
      */
     protected function get_blob_key_from_path(string $filepath): string {
-        return str_replace("blob://", '', $filepath);
+        return str_replace("azure://", '', $filepath);
     }
 
     /**
@@ -171,7 +171,7 @@ class client extends object_client_base {
      */
     public function get_seekable_stream_context() {
         $context = stream_context_create([
-            'blob' => [
+            'azure' => [
                 'seekable' => true,
             ],
         ]);

--- a/classes/local/store/azure_blob_storage/client.php
+++ b/classes/local/store/azure_blob_storage/client.php
@@ -256,19 +256,14 @@ class client extends object_client_base {
             return -1;
         }
 
-        // Parse the sas token (it just uses url parameter encoding).
-        $parts = [];
-        parse_str($this->config->azure_sastoken, $parts);
+        // Return expiry time, or default to 0 if could not parse.
+        $time = $this->api->get_token_expiry_time();
 
-        // Get the 'se' part (signed expiry).
-        if (!isset($parts['se'])) {
-            // Assume expired (malformed).
+        if (is_null($time)) {
             return 0;
         }
 
-        // Parse timestamp string into unix timestamp int.
-        $expirystr = $parts['se'];
-        return strtotime($expirystr);
+        return $time;
     }
 
     /**

--- a/classes/local/store/azure_blob_storage/client.php
+++ b/classes/local/store/azure_blob_storage/client.php
@@ -1,0 +1,296 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\local\store\azure_blob_storage;
+
+use admin_settingpage;
+use coding_exception;
+use GuzzleHttp\Psr7\Utils;
+use tool_objectfs\local\store\object_client_base;
+use local_azureblobstorage\api;
+use local_azureblobstorage\stream_wrapper;
+use stdClass;
+use Throwable;
+
+/**
+ * Azure blob storage client
+ *
+ * @package    tool_objectfs
+ * @author     Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright  2024 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class client extends object_client_base {
+
+    /** @var api $api Azure API */
+    protected api $api;
+
+    /**
+     * Creates object client
+     * @param stdClass $config / TODO is this maybe null ?
+     */
+    public function __construct($config) {
+        if (empty($config) || !$this->get_availability()) {
+            parent::__construct($config);
+            return;
+        }
+
+        $this->api = new api($config->azure_accountname, $config->azure_container, $config->azure_sastoken);
+        $this->config = $config;
+        $this->maxupload = api::MAX_BLOCK_SIZE;
+    }
+
+    /**
+     * Determines if this filesystem is available for use.
+     * @return bool
+     */
+    public function get_availability(): bool {
+        // Requires local_azureblobstorage to be installed.
+        // Namespace changed in 4.4+.
+        if (class_exists('\core\plugin_manager')) {
+            $info = \core\plugin_manager::instance()->get_plugin_info('local_azureblobstorage');
+            // For 4.2 and 4.3.
+        } else if (class_exists('\core_plugin_manager')) {
+            $info = \core_plugin_manager::instance()->get_plugin_info('local_azureblobstorage');
+        } else {
+            throw new coding_exception("Could not load plugin manager class");
+        }
+
+        // Info is empty if plugin is not installed or no API is setup (missing config?).
+        return !empty($info);
+    }
+
+    /**
+     * Sets the StreamWrapper to allow accessing the remote content via a blob:// path.
+     */
+    public function register_stream_wrapper() {
+        if ($this->get_availability()) {
+            stream_wrapper::register($this->api);
+        } else {
+            parent::register_stream_wrapper();
+        }
+    }
+
+    /**
+     * Returns the full path for a given file by contenthash
+     * @param string $contenthash
+     * @return string filepath
+     */
+    public function get_fullpath_from_hash($contenthash): string {
+        $filepath = $this->get_filepath_from_hash($contenthash);
+        return "blob://$filepath";
+    }
+
+    /**
+     * Returns the filepath from the contenthash, mimicking the
+     * structure of the filedir storage system.
+     * @param string $contenthash
+     * @return string filepath
+     */
+    protected function get_filepath_from_hash($contenthash): string {
+        $l1 = $contenthash[0] . $contenthash[1];
+        $l2 = $contenthash[2] . $contenthash[3];
+        return "$l1/$l2/$contenthash";
+    }
+
+    /**
+     * Returns the blob key (the key used to reference the blob) from a given filepath.
+     * @param string $filepath
+     * @return string
+     */
+    protected function get_blob_key_from_path(string $filepath): string {
+        return str_replace("blob://", '', $filepath);
+    }
+
+    /**
+     * Deletes a given file
+     * @param string $fullpath
+     */
+    public function delete_file($fullpath) {
+        // Stream wrapper supports unlinking, so just unlink.
+        unlink($fullpath);
+    }
+
+    /**
+     * Renames a given file
+     * @param string $currentpath
+     * @param string $destinationpath
+     */
+    public function rename_file($currentpath, $destinationpath) {
+        // Azure does not support renaming, instead the file is copied
+        // and the old one is deleted.
+        copy($currentpath, $destinationpath);
+        $this->delete_file($currentpath);
+    }
+
+    /**
+     * Verifies an object is uploaded correctly.
+     * In Azure, this is done by checking the md5 hash of the contents.
+     * @param string $contenthash
+     * @param string $localpath
+     * @return bool
+     */
+    public function verify_object($contenthash, $localpath) {
+        // If the object is uploaded to Azure the content will always be correct,
+        // because Azure will reject the original upload request if the md5 given during
+        // upload does not match.
+        // So here we just check the blob exists, and don't actually care about comparing the md5.
+        try {
+            // Just query the properties to confirm the file does indeed exist.
+            $key = $this->get_filepath_from_hash($contenthash);
+            $this->api->get_blob_properties_async($key)->wait();
+            return true;
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns a stream context used to handle file IO
+     * @return resource stream resource
+     */
+    public function get_seekable_stream_context() {
+        $context = stream_context_create([
+            'blob' => [
+                'seekable' => true,
+            ],
+        ]);
+        return $context;
+    }
+
+    /**
+     * Test permissions by uploading and doing various actions.
+     * @param bool $testdelete if should test deletion.
+     * @return stdClass containing 'success' and 'messages' values.
+     */
+    public function test_permissions($testdelete): stdClass {
+        $key = 'permissions_check_test';
+        $file = Utils::streamFor('test permission file');
+        $filemd5 = hex2bin(md5('test permission file'));
+
+        // Try create a file.
+        try {
+            $this->api->put_blob_async($key, $file, $filemd5)->wait();
+        } catch (Throwable $e) {
+            return (object) [
+                'success' => false,
+                'messages' => [get_string('settings:writefailure', 'tool_objectfs') . $e->getMessage() => 'notifyproblem'],
+            ];
+        }
+
+        // Try read the file that was created.
+        try {
+            $this->api->get_blob_async($key, $file, $filemd5)->wait();
+        } catch (Throwable $e) {
+            return (object) [
+                'success' => false,
+                'messages' => [get_string('settings:permissionreadfailure', 'tool_objectfs') . $e->getMessage() => 'notifyproblem'],
+            ];
+        }
+
+        // If testing delete, try delete the test file.
+        if ($testdelete) {
+            try {
+                $this->api->delete_blob_async($key)->wait();
+            } catch (Throwable $e) {
+                return (object) [
+                    'success' => false,
+                    'messages' => [get_string('settings:deleteerror', 'tool_objectfs') . $e->getMessage() => 'notifyproblem'],
+                ];
+            }
+        }
+
+        return (object) [
+            'success' => true,
+            'messages' => [get_string('settings:permissioncheckpassed', 'tool_objectfs') => 'notifysuccess'],
+        ];
+    }
+
+    /**
+     * Tests connection
+     * @return stdClass with 'success' and 'details' values.
+     */
+    public function test_connection(): stdClass {
+        // Try to create a file.
+        try {
+            $this->api->put_blob_async('connection_check_test', Utils::streamFor('test contents'), hex2bin(md5('test contents')));
+        } catch (Throwable $e) {
+            return (object) [
+                'success' => false,
+                'details' => $e->getMessage(),
+            ];
+        }
+
+        return (object) [
+            'success' => true,
+            'details' => '',
+        ];
+    }
+
+    /**
+     * Returns token expiry time
+     * @return int
+     */
+    public function get_token_expiry_time(): int {
+        if (empty($this->config->azure_sastoken)) {
+            return -1;
+        }
+
+        // Parse the sas token (it just uses url parameter encoding).
+        $parts = [];
+        parse_str($this->config->azure_sastoken, $parts);
+
+        // Get the 'se' part (signed expiry).
+        if (!isset($parts['se'])) {
+            // Assume expired (malformed).
+            return 0;
+        }
+
+        // Parse timestamp string into unix timestamp int.
+        $expirystr = $parts['se'];
+        return strtotime($expirystr);
+    }
+
+    /**
+     * Azure settings form with the following elements:
+     *
+     * Storage account name.
+     * Container name.
+     * Shared Access Signature.
+     *
+     * @param admin_settingpage $settings
+     * @param  \stdClass $config
+     * @return admin_settingpage
+     */
+    public function define_client_section($settings, $config): admin_settingpage {
+        $settings->add(new \admin_setting_heading('tool_objectfs/azure',
+            new \lang_string('settings:azure:header', 'tool_objectfs'), $this->define_client_check()));
+
+        $settings->add(new \admin_setting_configtext('tool_objectfs/azure_accountname',
+            new \lang_string('settings:azure:accountname', 'tool_objectfs'),
+            new \lang_string('settings:azure:accountname_help', 'tool_objectfs'), ''));
+
+        $settings->add(new \admin_setting_configtext('tool_objectfs/azure_container',
+            new \lang_string('settings:azure:container', 'tool_objectfs'),
+            new \lang_string('settings:azure:container_help', 'tool_objectfs'), ''));
+
+        $settings->add(new \admin_setting_configpasswordunmask('tool_objectfs/azure_sastoken',
+            new \lang_string('settings:azure:sastoken', 'tool_objectfs'),
+            new \lang_string('settings:azure:sastoken_help', 'tool_objectfs'), ''));
+
+        return $settings;
+    }
+}

--- a/classes/local/store/azure_blob_storage/client.php
+++ b/classes/local/store/azure_blob_storage/client.php
@@ -18,6 +18,7 @@ namespace tool_objectfs\local\store\azure_blob_storage;
 
 use admin_settingpage;
 use coding_exception;
+use Exception;
 use GuzzleHttp\Psr7\Utils;
 use tool_objectfs\local\store\object_client_base;
 use local_azureblobstorage\api;
@@ -133,6 +134,12 @@ class client extends object_client_base {
         // Azure does not support renaming, instead the file is copied
         // and the old one is deleted.
         copy($currentpath, $destinationpath);
+
+        // Ensure file exists as a fail-safe.
+        if (!is_readable($destinationpath)) {
+            throw new Exception("Rename (copy and delete) failed because copy operation failed, skipping deletion.");
+        }
+
         $this->delete_file($currentpath);
     }
 

--- a/classes/local/store/azure_blob_storage/file_system.php
+++ b/classes/local/store/azure_blob_storage/file_system.php
@@ -14,37 +14,26 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * File system for Azure Blob Storage.
- *
- * @package    tool_objectfs
- * @author     Nicholas Hoobin <nicholashoobin@catalyst-au.net>
- * @copyright  Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace tool_objectfs\local\store\azure_blob_storage;
 
-namespace tool_objectfs\local\store\azure;
-
-defined('MOODLE_INTERNAL') || die();
-
+use tool_objectfs\local\store\azure_blob_storage\client;
 use tool_objectfs\local\store\object_file_system;
 
-require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
-
 /**
- * file_system
- * @deprecated Since Moodle 4.2 - Please see the README about updating to new azure_blob_storage client.
+ * Azure blob store file system
+ *
+ * @package    tool_objectfs
+ * @author     Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright  2024 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class file_system extends object_file_system {
-
     /**
-     * initialise_external_client
+     * Initialise client
      * @param mixed $config
-     *
      * @return client
      */
     protected function initialise_external_client($config) {
-        $asclient = new client($config);
-        return $asclient;
+        return new client($config);
     }
 }

--- a/classes/local/store/digitalocean/client.php
+++ b/classes/local/store/digitalocean/client.php
@@ -40,7 +40,6 @@ class client extends s3_client {
     public function __construct($config) {
         global $CFG;
         $this->autoloader = $CFG->dirroot . '/local/aws/sdk/aws-autoloader.php';
-        $this->testdelete = false;
 
         if ($this->get_availability() && !empty($config)) {
             require_once($this->autoloader);

--- a/classes/local/store/object_client.php
+++ b/classes/local/store/object_client.php
@@ -141,6 +141,12 @@ interface object_client {
      * @return int unix timestamp the token set expires at
      */
     public function get_token_expiry_time(): int;
+
+    /**
+     * If should test deletion as part of testing connection.
+     * @return bool
+     */
+    public function should_test_delete(): bool;
 }
 
 

--- a/classes/local/store/object_client_base.php
+++ b/classes/local/store/object_client_base.php
@@ -39,10 +39,6 @@ abstract class object_client_base implements object_client {
      */
     protected $expirationtime;
     /**
-     * @var bool
-     */
-    protected $testdelete = true;
-    /**
      * @var int
      */
     public $presignedminfilesize;
@@ -56,6 +52,15 @@ abstract class object_client_base implements object_client {
 
     /** @var object $config Client config. */
     protected $config;
+
+    /**
+     * If deletion should be tested.
+     * Only tested when the deleteexternal setting is not set to 'no'
+     * @return bool
+     */
+    public function should_test_delete(): bool {
+        return !empty($this->config) && $this->config->deleteexternal != TOOL_OBJECTFS_DELETE_EXTERNAL_NO;
+    }
 
     /**
      * construct
@@ -120,7 +125,7 @@ abstract class object_client_base implements object_client {
         if ($connection->success) {
             $output .= $OUTPUT->notification(get_string('settings:connectionsuccess', 'tool_objectfs'), 'notifysuccess');
             // Check permissions if we can connect.
-            $permissions = $this->test_permissions($this->testdelete);
+            $permissions = $this->test_permissions($this->should_test_delete());
             if ($permissions->success) {
                 $output .= $OUTPUT->notification(key($permissions->messages), 'notifysuccess');
             } else {

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -767,7 +767,7 @@ class client extends object_client_base {
             if ($connection->success) {
                 $output .= $OUTPUT->notification(get_string('settings:aws:sdkcredsok', 'tool_objectfs'), 'notifysuccess');
                 // Check permissions if we can connect.
-                $permissions = $this->test_permissions($this->testdelete);
+                $permissions = $this->test_permissions($this->should_test_delete());
                 if ($permissions->success) {
                     $output .= $OUTPUT->notification(key($permissions->messages), 'notifysuccess');
                 } else {

--- a/classes/tests/test_azure_blob_storage_integration_client.php
+++ b/classes/tests/test_azure_blob_storage_integration_client.php
@@ -16,18 +16,17 @@
 
 namespace tool_objectfs\tests;
 
-use tool_objectfs\local\store\azure\client;
+use tool_objectfs\local\store\azure_blob_storage\client;
 
 /**
- * Client used for integration testing azure client
+ * Client used for integration testing azure blob storage client
  *
  * @package   tool_objectfs
- * @copyright Catalyst IT
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright 2024 Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @deprecated Since Moodle 4.2 - Please see the README about updating to new azure_blob_storage client.
  */
-class test_azure_integration_client extends client {
-
+class test_azure_blob_storage_integration_client extends client {
     /**
      * @var string
      */
@@ -39,10 +38,7 @@ class test_azure_integration_client extends client {
      * @return void
      */
     public function __construct($config) {
-        // Set config directly. Calling __construct will do nothing
-        // since unit tests do not have the azure sdk installed.
-        $this->config = $config;
-
+        parent::__construct($config);
         $time = microtime();
         $this->runidentifier = md5($time);
     }
@@ -53,7 +49,7 @@ class test_azure_integration_client extends client {
      *
      * @return string
      */
-    protected function get_filepath_from_hash($contenthash) {
+    protected function get_filepath_from_hash($contenthash): string {
         $l1 = $contenthash[0] . $contenthash[1];
         $l2 = $contenthash[2] . $contenthash[3];
         $runidentifier = $this->runidentifier;

--- a/classes/tests/test_file_system.php
+++ b/classes/tests/test_file_system.php
@@ -64,6 +64,13 @@ class test_file_system extends object_file_system {
             $config->azure_sastoken = $credentials['azure_sastoken'];
             manager::set_objectfs_config($config);
             $client = new test_azure_integration_client($config);
+        } else if (isset($CFG->phpunit_objectfs_azure_blob_storage_integration_test_credentials)) {
+            $credentials = $CFG->phpunit_objectfs_azure_integration_test_credentials;
+            $config->azure_accountname = $credentials['azure_accountname'];
+            $config->azure_container = $credentials['azure_container'];
+            $config->azure_sastoken = $credentials['azure_sastoken'];
+            manager::set_objectfs_config($config);
+            $client = new test_azure_blob_storage_integration_client($config);
         } else if (isset($CFG->phpunit_objectfs_swift_integration_test_credentials)) {
             $credentials = $CFG->phpunit_objectfs_swift_integration_test_credentials;
             $config->openstack_authurl = $credentials['openstack_authurl'];

--- a/classes/tests/test_file_system.php
+++ b/classes/tests/test_file_system.php
@@ -65,7 +65,7 @@ class test_file_system extends object_file_system {
             manager::set_objectfs_config($config);
             $client = new test_azure_integration_client($config);
         } else if (isset($CFG->phpunit_objectfs_azure_blob_storage_integration_test_credentials)) {
-            $credentials = $CFG->phpunit_objectfs_azure_integration_test_credentials;
+            $credentials = $CFG->phpunit_objectfs_azure_blob_storage_integration_test_credentials;
             $config->azure_accountname = $credentials['azure_accountname'];
             $config->azure_container = $credentials['azure_container'];
             $config->azure_sastoken = $credentials['azure_sastoken'];

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -945,6 +945,13 @@ class object_file_system_test extends tests\testcase {
         $autoloaderref = $clientref->getParentClass()->getProperty('autoloader');
         $autoloaderref->setAccessible(true);
         $autoloader = $autoloaderref->getValue($this->filesystem->externalclient);
+
+        // If client does not have autoloader, skip test.
+        if (empty($autoloader)) {
+            $this->markTestSkipped("Client does not have autoloader");
+            return;
+        }
+
         $this->set_externalclient_config('autoloader', $autoloader . '_fake');
         $this->assertFalse($this->filesystem->is_configured());
     }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024102400;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024102400;      // Same as version.
+$plugin->version   = 2024110800;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2024110800;      // Same as version.
 $plugin->requires  = 2023042400;      // Requires 4.2.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
**Changes**
- Adds new `azure_blob_storage_file_system` class to replace the deprecated `azure_file_storage_system`.
    - This is intentionally added as an additional class (as opposed to renaming/fixing the old class) because the new class requires a new plugin dependency https://github.com/catalyst/moodle-local_azureblobstorage 
    - Having a new class allows time for admins to install the new plugin in parallel, and then switch over rather than suddenly finding the newest minor version update changed dependencies.
- Added documentation about migration process for the above
- Fixes a tiny bug in a test that assumed no files existed before the test
- Fixed a bug where testing deletion does not check if the fs even is allowed to delete, related to https://github.com/catalyst/moodle-tool_objectfs/issues/645 but does not completely resolve the issue for other fs's like AWS

**Testing**
- The new client class with the new sdk plugin pass the integration tests (the standard objectfs unit tests but attached to azure storage via the `azure_blob_storage_file_system`)
- Also tested locally the various CRUD operations including large files uploaded via multipart upload and large files streamed down (e.g. videos) in multipart - all working as expected