### PR TITLE
Remove local_aws dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This plugin is GDPR complient if you enable the deletion of remote objects.
 
 | Moodle version    | Totara version           | Branch                                                                                       | PHP  | MySQL   | PostgreSQL  |
 |-------------------|--------------------------|----------------------------------------------------------------------------------------------|------|---------|-------------|
+| Moodle 4.4+       |                          | [MOODLE_404_STABLE](https://github.com/catalyst/moodle-tool_objectfs/tree/MOODLE_404_STABLE) | 8.1+ | 8.0+    | 13+         |
 | Moodle 4.2+       |                          | [MOODLE_402_STABLE](https://github.com/catalyst/moodle-tool_objectfs/tree/MOODLE_402_STABLE) | 8.0+ | 8.0+    | 13+         |
 | Moodle 3.10 - 4.1 |                          | [MOODLE_310_STABLE](https://github.com/catalyst/moodle-tool_objectfs/tree/MOODLE_310_STABLE) | 7.2+ | 5.7+    | 12+         |
 
@@ -85,7 +86,7 @@ This plugin is GDPR complient if you enable the deletion of remote objects.
 2. Setup your remote object storage. See [Remote object storage setup](#amazon-s3)
 3. Clone this repository into admin/tool/objectfs
 4. Install one of the required SDK libraries for the storage file system that you will be using
-    1. Clone [moodle-local_aws](https://github.com/catalyst/moodle-local_aws) into local/aws for S3 or DigitalOcean Spaces or Google Cloud, or
+    1. AWS SDK: the SDK is already integrated into Moodle 4.4+
     2. Clone [moodle-local_azureblobstorage](https://github.com/catalyst/moodle-local_azureblobstorage) into local/azureblobstorage for Azure Blob Storage, or
     3. Clone [moodle-local_openstack](https://github.com/matt-catalyst/moodle-local_openstack.git) into local/openstack for openstack(swift) storage
 5. Install the plugins through the moodle GUI.

--- a/classes/local/store/digitalocean/client.php
+++ b/classes/local/store/digitalocean/client.php
@@ -38,16 +38,21 @@ class client extends s3_client {
      * @return void
      */
     public function __construct($config) {
-        global $CFG;
-        $this->autoloader = $CFG->dirroot . '/local/aws/sdk/aws-autoloader.php';
-
         if ($this->get_availability() && !empty($config)) {
-            require_once($this->autoloader);
             $this->bucket = $config->do_space;
             $this->set_client($config);
         } else {
             parent::__construct($config);
         }
+    }
+
+    /**
+     * We do not need to check for the autoloader as AWS SDK is integrated in to Moodle 4.4
+     *
+     * @return bool
+     */
+    public function get_availability() {
+        return true;
     }
 
     /**

--- a/classes/local/store/s3/admin_settings_aws_region.php
+++ b/classes/local/store/s3/admin_settings_aws_region.php
@@ -1,0 +1,87 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Admin setting for AWS regions.
+ *
+ * @package    tool_objectfs
+ * @author     Dmitrii Metelkin <dmitriim@catalyst-au.net>
+ * @copyright  2020 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_objectfs\local\store\s3;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot . '/lib/adminlib.php');
+
+/**
+ * Admin setting for a list of AWS regions.
+ *
+ * @package    tool_objectfs
+ * @copyright  2020 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class admin_settings_aws_region extends \admin_setting_configtext {
+
+    /**
+     * Return part of form with setting.
+     *
+     * @param mixed $data array or string depending on setting
+     * @param string $query
+     * @return string
+     */
+    public function output_html($data, $query='') {
+        global $CFG;
+
+        $default = $this->get_defaultsetting();
+
+        $options = [];
+
+        $all = require($CFG->dirroot . '/lib/aws-sdk/src/data/endpoints.json.php');
+        $ends = $all['partitions'][0]['regions'];
+        if ($ends) {
+            foreach ($ends as $key => $value) {
+                $options[] = [
+                    'value' => $key,
+                    'label' => $key . ' - ' . $value['description'],
+                ];
+            }
+        }
+
+        $inputparams = array(
+            'type' => 'text',
+            'list' => $this->get_full_name(),
+            'name' => $this->get_full_name(),
+            'value' => $data,
+            'size' => $this->size,
+            'id' => $this->get_id(),
+            'class' => 'form-control text-ltr',
+        );
+
+        $element = \html_writer::start_tag('div', array('class' => 'form-text defaultsnext'));
+        $element .= \html_writer::empty_tag('input', $inputparams);
+        $element .= \html_writer::start_tag('datalist', array('id' => $this->get_full_name()));
+        foreach ($options as $option) {
+            $element .= \html_writer::tag('option', $option['label'], array('value' => $option['value']));
+        }
+        $element .= \html_writer::end_tag('datalist');
+        $element .= \html_writer::end_tag('div');
+
+        return format_admin_setting($this, $this->visiblename, $element, $this->description, true, '', $default, $query);
+    }
+}

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -120,8 +120,6 @@ $string['settings:aws:region'] = 'region';
 $string['settings:aws:region_help'] = 'Amazon S3 API gateway region.';
 $string['settings:aws:base_url'] = 'Base URL';
 $string['settings:aws:base_url_help'] = 'Alternate url for cnames or s3 compatible endpoints. Leave blank for normal S3 use.';
-$string['settings:aws:upgradeneeded'] = 'Please upgrade \'local_aws\' plugin to the latest supported version.';
-$string['settings:aws:installneeded'] = 'Please install \'local_aws\' plugin.';
 $string['settings:aws:usesdkcreds'] = 'Use the default credential provider chain to find AWS credentials';
 $string['settings:aws:sdkcredsok'] = 'AWS credentials found. This setting can be safely enabled.';
 $string['settings:aws:sdkcredserror'] = 'Couldn\'t find AWS credentials. It\'s unsafe to enable this setting. Follow up <a href="https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html">AWS documentation</a>.';

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024110800;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024110800;      // Same as version.
-$plugin->requires  = 2023042400;      // Requires 4.2.
+$plugin->version   = 2024112000;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2024112000;      // Same as version.
+$plugin->requires  = 2024042200;      // Requires 4.4.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->supported = [402, 405];
+$plugin->supported = [404, 405];


### PR DESCRIPTION
- AWS SDK is integrated into Moodle 4.4+
- Remove dependency on local_aws
- core admin_settings_aws_region  (added since Moodle 4.4)  is deprecated in Moodle 4.5
- Support Moodle 4.4 and 4.5