### PR TITLE
Add object tagging - Moodle 404

### DIFF
--- a/TAGGING.md
+++ b/TAGGING.md
@@ -1,0 +1,65 @@
+# Tagging
+Tagging allows extra metadata about your files to be send to the external object store. These sources are defined in code, and currently cannot be configured on/off from the UI.
+
+Currently, this is only implemented for the S3 file system client. 
+**Tagging vs metadata**
+
+Note object tags are different from object metadata.
+
+Object metadata is immutable, and attached to the object on upload. With metadata, if you wish to update it (for example during a migration, or the sources changed), you have to copy the object with the new metadata, and delete the old object. This is not ideal, since deletion is optional in objectfs.
+
+Object tags are more suitable, since their permissions can be managed separately (e.g. a client can be allowed to modify tags, but not delete objects).
+
+## File system setup
+### S3
+[See the S3 docs for more information about tagging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html).
+
+You must allow `s3:GetObjectTagging` and `s3:PutObjectTagging` permission to the objectfs client.
+
+## Sources
+The following sources are implemented currently:
+### Environment
+What environment the file was uploaded in. Configure the environment using `taggingenvironment` in the objectfs plugin settings.
+
+This tag is also used by objectfs to determine if tags can be overwritten. See [Multiple environments setup](#multiple-environments-setup) for more information.
+
+### Location
+Either `orphan` if the file no longer exists in the `files` table in Moodle, otherwise `active`.
+
+## Multiple environments setup
+This feature is designed to work in situations where multiple environments (e.g. prod, staging) points to the same bucket, however, some setup is needed:
+
+1. Turn off `overwriteobjecttags` in every environment except the production environment.
+2. Configure `taggingenvironment` to be unique for all environments.
+
+By doing the above two steps, it will allow the production environment to always set its own tags, even if a file was first uploaded to staging and then to production.
+
+Lower environments can still update tags, but only if the `environment` matches theirs. This allows staging to manage object tags on objects only it knows about, but as soon as the file is uploaded from production (and therefore have it's environment tag replaced with `prod`), staging will no longer touch it.
+
+## Migration
+Only new objects uploaded after enabling this feature will have tags added. To backfill tags for previously uploaded objects, you must do the following:
+
+- Manually run `trigger_update_object_tags` scheduled task from the UI, which queues a `update_object_tags` adhoc task that will process all objects marked as needing sync.
+or
+- Call the CLI to execute a `update_object_tags` adhoc task manually.
+
+You may need to update the DB to mark objects tag sync status as needing sync if the object has previously been synced before.
+## Reporting
+There is an additional graph added to the object summary report showing the tag value combinations and counts of each.
+
+Note, this is only for files that have been uploaded from the respective environment, and may not be consistent for environments where `overwriteobjecttags` is disabled (because the site does not know if a file was overwritten in the external store by another client).
+
+## For developers
+
+### Adding a new source
+Note the rules about sources:
+- Identifier must be < 32 chars long.
+- Value must be < 128 chars long.
+
+While external providers allow longer key/values, we intentionally limit it to reserve space for future use. These limits may change in the future as the feature matures.
+
+To add a new source:
+- Implement `tag_source`
+- Add to the `tag_manager` class
+- As part of an upgrade step, mark all objects `tagsyncstatus` to needing sync (using `tag_manager` class, or manually in the DB)
+- As part of an upgrade step, queue a `update_object_tags` adhoc task to process the tag migration.

--- a/classes/check/tagging_migration_status.php
+++ b/classes/check/tagging_migration_status.php
@@ -1,0 +1,80 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\check;
+
+use core\check\check;
+use core\check\result;
+use core\task\manager;
+use html_table;
+use html_writer;
+use tool_objectfs\task\update_object_tags;
+
+/**
+ * Tagging migration status check
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tagging_migration_status extends check {
+    /**
+     * Link to ObjectFS settings page.
+     *
+     * @return \action_link|null
+     */
+    public function get_action_link(): ?\action_link {
+        $url = new \moodle_url('/admin/category.php', ['category' => 'tool_objectfs']);
+        return new \action_link($url, get_string('pluginname', 'tool_objectfs'));
+    }
+
+    /**
+     * Get result
+     * @return result
+     */
+    public function get_result(): result {
+        // We want to check this regardless if enabled or supported and not exit early.
+        // Because it may have been turned off accidentally thus causing the migration to fail.
+        $tasks = manager::get_adhoc_tasks(update_object_tags::class);
+
+        if (empty($tasks)) {
+            return new result(result::NA, get_string('tagging:migration:nothingrunning', 'tool_objectfs'));
+        }
+
+        $table = new html_table();
+        $table->head = [
+            get_string('table:taskid', 'tool_objectfs'),
+            get_string('table:iteration', 'tool_objectfs'),
+            get_string('table:status', 'tool_objectfs'),
+        ];
+
+        foreach ($tasks as $task) {
+            $table->data[$task->get_id()] = [$task->get_id(), $task->get_iteration(), $task->get_status_badge()];
+        }
+        $html = html_writer::table($table);
+
+        $ataskisfailing = !empty(array_filter($tasks, function($task) {
+            return $task->get_fail_delay() > 0;
+        }));
+
+        if ($ataskisfailing) {
+            return new result(result::WARNING, get_string('check:tagging:migrationerror', 'tool_objectfs'), $html);
+        }
+
+        return new result(result::OK, get_string('check:tagging:migrationok', 'tool_objectfs'), $html);
+    }
+}

--- a/classes/check/tagging_status.php
+++ b/classes/check/tagging_status.php
@@ -1,0 +1,62 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\check;
+
+use core\check\check;
+use core\check\result;
+use tool_objectfs\local\tag\tag_manager;
+
+/**
+ * Tagging status check
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tagging_status extends check {
+    /**
+     * Link to ObjectFS settings page.
+     *
+     * @return \action_link|null
+     */
+    public function get_action_link(): ?\action_link {
+        $url = new \moodle_url('/admin/category.php', ['category' => 'tool_objectfs']);
+        return new \action_link($url, get_string('pluginname', 'tool_objectfs'));
+    }
+
+    /**
+     * Get result
+     * @return result
+     */
+    public function get_result(): result {
+        if (!tag_manager::is_tagging_enabled_and_supported()) {
+            return new result(result::NA, get_string('check:tagging:na', 'tool_objectfs'));
+        }
+
+        // Do a tag set test.
+        $config = \tool_objectfs\local\manager::get_objectfs_config();
+        $client = \tool_objectfs\local\manager::get_client($config);
+        $result = $client->test_set_object_tag();
+
+        if ($result->success) {
+            return new result(result::OK, get_string('check:tagging:ok', 'tool_objectfs'), $result->details);
+        } else {
+            return new result(result::ERROR, get_string('check:tagging:error', 'tool_objectfs'), $result->details);
+        }
+    }
+}

--- a/classes/check/tagging_sync_status.php
+++ b/classes/check/tagging_sync_status.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\check;
+
+use core\check\check;
+use core\check\result;
+use tool_objectfs\local\tag\tag_manager;
+use tool_objectfs\local\tag_sync_count_result;
+
+/**
+ * Tagging sync status check
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tagging_sync_status extends check {
+    /**
+     * Link to ObjectFS settings page.
+     *
+     * @return \action_link|null
+     */
+    public function get_action_link(): ?\action_link {
+        $url = new \moodle_url('/admin/category.php', ['category' => 'tool_objectfs']);
+        return new \action_link($url, get_string('pluginname', 'tool_objectfs'));
+    }
+
+    /**
+     * Get result
+     * @return result
+     */
+    public function get_result(): result {
+        if (!tag_manager::is_tagging_enabled_and_supported()) {
+            return new tag_sync_count_result(result::NA, get_string('check:tagging:na', 'tool_objectfs'));
+        }
+
+        // We only do a lightweight check here, the get_details is overwritten in tag_sync_status_result
+        // to provide more information that is more computationally expensive to calculate.
+        if (tag_manager::tag_sync_errors_exist()) {
+            return new tag_sync_count_result(result::WARNING, get_string('check:tagging:syncerror', 'tool_objectfs'));
+        }
+
+        return new tag_sync_count_result(result::OK, get_string('check:tagging:syncok', 'tool_objectfs'));
+    }
+}

--- a/classes/local/manager.php
+++ b/classes/local/manager.php
@@ -27,6 +27,7 @@ namespace tool_objectfs\local;
 
 use stdClass;
 use tool_objectfs\local\store\object_file_system;
+use tool_objectfs\local\tag\tag_manager;
 
 /**
  * [Description manager]
@@ -64,6 +65,7 @@ class manager {
         $config->batchsize = 10000;
         $config->useproxy = 0;
         $config->deleteexternal = 0;
+        $config->enabletagging = false;
 
         $config->filesystem = '';
         $config->enablepresignedurls = 0;
@@ -159,7 +161,7 @@ class manager {
             $newobject->filesize = isset($oldobject->filesize) ? $oldobject->filesize :
                     $DB->get_field('files', 'filesize', ['contenthash' => $contenthash], IGNORE_MULTIPLE);
 
-            return self::update_object($newobject, $newlocation);
+            return self::upsert_object($newobject, $newlocation);
         }
         $newobject->location = $newlocation;
 
@@ -172,9 +174,7 @@ class manager {
             $newobject->filesize = $filesize;
             $newobject->timeduplicated = time();
         }
-        $DB->insert_record('tool_objectfs_objects', $newobject);
-
-        return $newobject;
+        return self::upsert_object($newobject, $newlocation);
     }
 
     /**
@@ -184,7 +184,7 @@ class manager {
      * @return stdClass
      * @throws \dml_exception
      */
-    public static function update_object(stdClass $object, $newlocation) {
+    public static function upsert_object(stdClass $object, $newlocation) {
         global $DB;
 
         // If location change is 'duplicated' we update timeduplicated.
@@ -192,8 +192,21 @@ class manager {
             $object->timeduplicated = time();
         }
 
+        $locationchanged = !isset($object->location) || $object->location != $newlocation;
         $object->location = $newlocation;
-        $DB->update_record('tool_objectfs_objects', $object);
+
+        // If id is set, update, else insert new.
+        if (empty($object->id)) {
+            $object->id = $DB->insert_record('tool_objectfs_objects', $object);
+        } else {
+            $DB->update_record('tool_objectfs_objects', $object);
+        }
+
+        // Post update, notify tag manager since the location tag likely needs changing.
+        if ($locationchanged && tag_manager::is_tagging_enabled_and_supported()) {
+            $fs = get_file_storage()->get_file_system();
+            $fs->push_object_tags($object->contenthash);
+        }
 
         return $object;
     }

--- a/classes/local/object_manipulator/manipulator.php
+++ b/classes/local/object_manipulator/manipulator.php
@@ -111,7 +111,7 @@ abstract class manipulator implements object_manipulator {
 
             $newlocation = $this->manipulate_object($objectrecord);
             if (!empty($objectrecord->id)) {
-                manager::update_object($objectrecord, $newlocation);
+                manager::upsert_object($objectrecord, $newlocation);
             } else {
                 manager::update_object_by_hash($objectrecord->contenthash, $newlocation);
             }

--- a/classes/local/report/object_status_history_table.php
+++ b/classes/local/report/object_status_history_table.php
@@ -74,6 +74,11 @@ class object_status_history_table extends \table_sql {
             $columnheaders['runningsize'] = get_string('object_status:runningsize', 'tool_objectfs');
         }
 
+        // Tag count report does not display the size.
+        if ($this->reporttype == 'tag_count') {
+            unset($columnheaders['size']);
+        }
+
         $this->set_attribute('class', 'table-sm');
         $this->define_columns(array_keys($columnheaders));
         $this->define_headers(array_values($columnheaders));

--- a/classes/local/report/objectfs_report.php
+++ b/classes/local/report/objectfs_report.php
@@ -78,7 +78,8 @@ class objectfs_report implements \renderable {
      */
     public function add_rows(array $rows) {
         foreach ($rows as $row) {
-            $this->add_row($row->datakey, $row->objectcount, $row->objectsum);
+            // Note objectsum is optional.
+            $this->add_row($row->datakey, $row->objectcount, $row->objectsum ?? 0);
         }
     }
 
@@ -166,6 +167,7 @@ class objectfs_report implements \renderable {
             'location',
             'log_size',
             'mime_type',
+            'tag_count',
         ];
     }
 

--- a/classes/local/report/tag_count_report_builder.php
+++ b/classes/local/report/tag_count_report_builder.php
@@ -1,0 +1,48 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\local\report;
+
+/**
+ * Tag count report builder.
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tag_count_report_builder extends objectfs_report_builder {
+    /**
+     * Builds report
+     * @param int $reportid
+     * @return objectfs_report
+     */
+    public function build_report($reportid) {
+        global $DB;
+        $report = new objectfs_report('tag_count', $reportid);
+
+        // Returns counts of key:value.
+        $sql = "
+            SELECT CONCAT(COALESCE(object_tags.tagkey, '(untagged)'), ': ', COALESCE(object_tags.tagvalue, '')) as datakey,
+                   COUNT(DISTINCT object_tags.objectid) as objectcount
+              FROM {tool_objectfs_object_tags} object_tags
+          GROUP BY object_tags.tagkey, object_tags.tagvalue
+        ";
+        $result = $DB->get_records_sql($sql);
+        $report->add_rows($result);
+        return $report;
+    }
+}

--- a/classes/local/store/object_client.php
+++ b/classes/local/store/object_client.php
@@ -16,6 +16,8 @@
 
 namespace tool_objectfs\local\store;
 
+use stdClass;
+
 /**
  * Objectfs client interface.
  *
@@ -147,6 +149,32 @@ interface object_client {
      * @return bool
      */
     public function should_test_delete(): bool;
+
+    /**
+     * Tests setting an objects tag.
+     * @return stdClass containing 'success' and 'details' properties
+     */
+    public function test_set_object_tag(): stdClass;
+
+    /**
+     * Set the given objects tags in the external store.
+     * @param string $contenthash file content hash
+     * @param array $tags array of key=>value pairs to set as tags.
+     */
+    public function set_object_tags(string $contenthash, array $tags);
+
+    /**
+     * Returns given objects tags queried from the external store. External object must exist.
+     * @param string $contenthash file content has
+     * @return array array of key=>value tag pairs
+     */
+    public function get_object_tags(string $contenthash): array;
+
+    /**
+     * If the client supports object tagging feature.
+     * @return bool true if supports, else false
+     */
+    public function supports_object_tagging(): bool;
 }
 
 

--- a/classes/local/store/object_client_base.php
+++ b/classes/local/store/object_client_base.php
@@ -25,6 +25,8 @@
 
 namespace tool_objectfs\local\store;
 
+use stdClass;
+
 /**
  * [Description object_client_base]
  */
@@ -200,5 +202,39 @@ abstract class object_client_base implements object_client {
     public function get_token_expiry_time(): int {
         // Returning -1 = not implemented.
         return -1;
+    }
+
+    /**
+     * Tests setting an objects tag.
+     * @return stdClass containing 'success' and 'details' properties
+     */
+    public function test_set_object_tag(): stdClass {
+        return (object)['success' => false, 'details' => ''];
+    }
+
+    /**
+     * Set the given objects tags in the external store.
+     * @param string $contenthash file content hash
+     * @param array $tags array of key=>value pairs to set as tags.
+     */
+    public function set_object_tags(string $contenthash, array $tags) {
+        return [];
+    }
+
+    /**
+     * Returns given objects tags queried from the external store. External object must exist.
+     * @param string $contenthash file content has
+     * @return array array of key=>value tag pairs
+     */
+    public function get_object_tags(string $contenthash): array {
+        return [];
+    }
+
+    /**
+     * If the client supports object tagging feature.
+     * @return bool true if supports, else false
+     */
+    public function supports_object_tagging(): bool {
+        return false;
     }
 }

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -25,9 +25,13 @@
 
 namespace tool_objectfs\local\store\s3;
 
+use coding_exception;
 use tool_objectfs\local\manager;
 use tool_objectfs\local\store\object_client_base;
 use tool_objectfs\local\store\signed_url;
+use local_aws\admin_settings_aws_region;
+use stdClass;
+use Throwable;
 
 define('AWS_API_VERSION', '2006-03-01');
 define('AWS_CAN_READ_OBJECT', 0);
@@ -480,10 +484,11 @@ class client extends object_client_base {
      *
      * @param string $localpath Path to a local file.
      * @param string $contenthash Content hash of the file.
+     * @param string $mimetype the mimetype of the file being uploaded
      *
      * @throws \Exception if fails.
      */
-    public function upload_to_s3($localpath, $contenthash) {
+    public function upload_to_s3($localpath, $contenthash, string $mimetype) {
         $filehandle = fopen($localpath, 'rb');
 
         if (!$filehandle) {
@@ -495,7 +500,13 @@ class client extends object_client_base {
             $uploader = new \Aws\S3\ObjectUploader(
                 $this->client, $this->bucket,
                 $this->bucketkeyprefix . $externalpath,
-                $filehandle
+                $filehandle,
+                'private',
+                [
+                    'params' => [
+                        'ContentType' => $mimetype,
+                    ],
+                ]
             );
             $uploader->upload();
             fclose($filehandle);
@@ -861,5 +872,114 @@ class client extends object_client_base {
             }
         }
         return (object)['result' => false, 'error' => get_string('fixturefilemissing', 'tool_objectfs')];
+    }
+
+    /**
+     * Tests setting an objects tag.
+     * @return stdClass containing 'success' and 'details' properties
+     */
+    public function test_set_object_tag(): stdClass {
+        try {
+            // First ensure a test object exists to put tags on.
+            // Note this will override the existing object if exists.
+            $key = $this->bucketkeyprefix . 'tagging_check_file';
+            $this->client->putObject([
+                'Bucket' => $this->bucket,
+                'Key' => $key,
+                'Body' => 'test content',
+            ]);
+
+            // Next try to tag it - this will throw an exception if cannot set
+            // (for example, because it does not have permissions to).
+            $this->client->putObjectTagging([
+                'Bucket' => $this->bucket,
+                'Key' => $key,
+                'Tagging' => [
+                    'TagSet' => [
+                        [
+                            'Key' => 'test',
+                            'Value' => 'test',
+                        ],
+                    ],
+                ],
+            ]);
+        } catch (Throwable $e) {
+            return (object) [
+                'success' => false,
+                'details' => $e->getMessage(),
+            ];
+        }
+
+        // Success - no exceptions thrown.
+        return (object) ['success' => true, 'details' => ''];
+    }
+
+    /**
+     * Convert key=>value to s3 tag format
+     * @param array $tags
+     * @return array tags in s3 format.
+     */
+    private function convert_tags_to_s3_format(array $tags): array {
+        foreach ($tags as $key => $value) {
+            $s3tags[] = [
+                'Key' => $key,
+                'Value' => $value,
+            ];
+        }
+        return $s3tags;
+    }
+
+    /**
+     * Set the given objects tags in the external store.
+     * @param string $contenthash file content hash
+     * @param array $tags array of key=>value pairs to set as tags.
+     */
+    public function set_object_tags(string $contenthash, array $tags) {
+        $objectkey = $this->bucketkeyprefix . $this->get_filepath_from_hash($contenthash);
+
+        // Then put onto object.
+        $this->client->putObjectTagging([
+            'Bucket' => $this->bucket,
+            'Key' => $objectkey,
+            'Tagging' => [
+                'TagSet' => $this->convert_tags_to_s3_format($tags),
+            ],
+        ]);
+    }
+
+    /**
+     * Returns given objects tags queried from the external store. Object must exist.
+     * @param string $contenthash file content has
+     * @return array array of key=>value tag pairs
+     */
+    public function get_object_tags(string $contenthash): array {
+        $objectkey = $this->bucketkeyprefix . $this->get_filepath_from_hash($contenthash);
+
+        // Query from S3.
+        $result = $this->client->getObjectTagging([
+            'Bucket' => $this->bucket,
+            'Key' => $objectkey,
+        ]);
+
+        // Ensure tags are what we expect, and AWS have not changed the format.
+        if (!array_key_exists('TagSet', $result->toArray())) {
+            throw new coding_exception("Unexpected tag format received. Result did not contain a TagSet");
+        }
+
+        // Convert from S3 format to key=>value format.
+        $tagkv = [];
+        foreach ($result->toArray()['TagSet'] as $tag) {
+            $tagkv[$tag['Key']] = $tag['Value'];
+        }
+
+        return $tagkv;
+    }
+
+    /**
+     * If the client supports object tagging feature.
+     * @return bool true if supports, else false
+     */
+    public function supports_object_tagging(): bool {
+        return true;
     }
 }

--- a/classes/local/store/s3/file_system.php
+++ b/classes/local/store/s3/file_system.php
@@ -85,9 +85,10 @@ class file_system extends object_file_system {
      */
     public function copy_from_local_to_external($contenthash) {
         $localpath = $this->get_local_path_from_hash($contenthash);
+        $mime = $this->get_mimetype_from_hash($contenthash);
 
         try {
-            $this->get_external_client()->upload_to_s3($localpath, $contenthash);
+            $this->get_external_client()->upload_to_s3($localpath, $contenthash, $mime);
             return true;
         } catch (\Exception $e) {
             $this->get_logger()->error_log(

--- a/classes/local/tag/environment_source.php
+++ b/classes/local/tag/environment_source.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\local\tag;
+
+use moodle_exception;
+
+/**
+ * Provides current environment to file.
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class environment_source implements tag_source {
+    /**
+     * Identifier used in tagging file. Is the 'key' of the tag.
+     * @return string
+     */
+    public static function get_identifier(): string {
+        return 'environment';
+    }
+
+    /**
+     * Description for source displayed in the admin settings.
+     * @return string
+     */
+    public static function get_description(): string {
+        return get_string('tagsource:environment', 'tool_objectfs', self::get_env());
+    }
+
+    /**
+     * Returns current env value from $CFG
+     * @return string|null string if set, else null
+     */
+    private static function get_env(): ?string {
+        $value = get_config('tool_objectfs', 'taggingenvironment');
+
+        if (empty($value)) {
+            return null;
+        }
+
+        // Must never be greater than 128, unlikely, but we must enforce this.
+        if (strlen($value) > 128) {
+            throw new moodle_exception('tagsource:environment:toolong', 'tool_objectfs');
+        }
+
+        return $value;
+    }
+
+    /**
+     * Returns the tag value for the given file contenthash
+     * @param string $contenthash
+     * @return string|null environment value.
+     */
+    public function get_value_for_contenthash(string $contenthash): ?string {
+        return self::get_env();
+    }
+}

--- a/classes/local/tag/location_source.php
+++ b/classes/local/tag/location_source.php
@@ -1,0 +1,57 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\local\tag;
+
+/**
+ * Provides location status for a file.
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class location_source implements tag_source {
+    /**
+     * Identifier used in tagging file. Is the 'key' of the tag.
+     * @return string
+     */
+    public static function get_identifier(): string {
+        return 'location';
+    }
+
+    /**
+     * Description for source displayed in the admin settings.
+     * @return string
+     */
+    public static function get_description(): string {
+        return get_string('tagsource:location', 'tool_objectfs');
+    }
+
+    /**
+     * Returns the tag value for the given file contenthash
+     * @param string $contenthash
+     * @return string|null mime type for file.
+     */
+    public function get_value_for_contenthash(string $contenthash): ?string {
+        global $DB;
+
+        $isorphaned = $DB->record_exists('tool_objectfs_objects', ['contenthash' => $contenthash,
+            'location' => OBJECT_LOCATION_ORPHANED]);
+
+        return $isorphaned ? 'orphan' : 'active';
+    }
+}

--- a/classes/local/tag/tag_manager.php
+++ b/classes/local/tag/tag_manager.php
@@ -1,0 +1,243 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\local\tag;
+
+use coding_exception;
+use html_table;
+use html_writer;
+use tool_objectfs\local\manager;
+
+defined('MOODLE_INTERNAL') || die();
+require_once($CFG->dirroot . '/admin/tool/objectfs/lib.php');
+
+/**
+ * Manages object tagging feature.
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tag_manager {
+
+    /**
+     * @var int If object needs sync. These will periodically be picked up by scheduled tasks and queued for syncing.
+     */
+    public const SYNC_STATUS_NEEDS_SYNC = 0;
+
+    /**
+     * @var int Object does not need sync. Will be essentially ignored in tagging process.
+     */
+    public const SYNC_STATUS_COMPLETE = 1;
+
+    /**
+     * @var int Object tried to sync but there was an error. Will make it ignored and must be corrected manually.
+     */
+    public const SYNC_STATUS_ERROR = 2;
+
+    /**
+     * @var array All possible tag sync statuses.
+     */
+    public const SYNC_STATUSES = [
+        self::SYNC_STATUS_NEEDS_SYNC,
+        self::SYNC_STATUS_COMPLETE,
+        self::SYNC_STATUS_ERROR,
+    ];
+
+    /**
+     * Returns an array of tag_source instances that are currently defined.
+     * @return array
+     */
+    public static function get_defined_tag_sources(): array {
+        // All possible tag sources should be defined here.
+        // Note this should be a maximum of 10 sources, as this is an AWS limit.
+        return [
+            new environment_source(),
+            new location_source(),
+        ];
+    }
+
+    /**
+     * Is the tagging feature enabled and supported by the configured fs?
+     * @return bool
+     */
+    public static function is_tagging_enabled_and_supported(): bool {
+        $enabledinconfig = !empty(get_config('tool_objectfs', 'taggingenabled'));
+
+        $client = manager::get_client(manager::get_objectfs_config());
+        $supportedbyfs = !empty($client) && $client->supports_object_tagging();
+
+        return $enabledinconfig && $supportedbyfs;
+    }
+
+    /**
+     * Gathers the tag values for a given content hash
+     * @param string $contenthash
+     * @return array array of key=>value pairs, the tags for the given file.
+     */
+    public static function gather_object_tags_for_upload(string $contenthash): array {
+        $tags = [];
+        foreach (self::get_defined_tag_sources() as $source) {
+            $val = $source->get_value_for_contenthash($contenthash);
+
+            // Null means not set for this object.
+            if (is_null($val)) {
+                continue;
+            }
+
+            $tags[$source->get_identifier()] = $val;
+        }
+        return $tags;
+    }
+
+    /**
+     * Stores tag records for contenthash locally
+     * @param string $contenthash
+     * @param array $tags
+     */
+    public static function store_tags_locally(string $contenthash, array $tags) {
+        global $DB;
+
+        // Lookup object id.
+        $objectid = $DB->get_field('tool_objectfs_objects', 'id', ['contenthash' => $contenthash], MUST_EXIST);
+
+        // Purge any existing tags for this object.
+        $DB->delete_records('tool_objectfs_object_tags', ['objectid' => $objectid]);
+
+        // Store new records.
+        $recordstostore = [];
+        foreach ($tags as $key => $value) {
+            $recordstostore[] = [
+                'objectid' => $objectid,
+                'tagkey' => $key,
+                'tagvalue' => $value,
+            ];
+        }
+        $DB->insert_records('tool_objectfs_object_tags', $recordstostore);
+    }
+
+    /**
+     * Returns objects that are candidates for tag syncing.
+     * @param int $limit max number of records to return
+     * @return array array of contenthashes, which need tags calculated and synced.
+     */
+    public static function get_objects_needing_sync(int $limit) {
+        global $DB;
+
+        // Find object records where the status is NEEDS_SYNC and is replicated.
+        [$insql, $inparams] = $DB->get_in_or_equal([
+            OBJECT_LOCATION_DUPLICATED, OBJECT_LOCATION_EXTERNAL, OBJECT_LOCATION_ORPHANED], SQL_PARAMS_NAMED);
+        $inparams['syncstatus'] = self::SYNC_STATUS_NEEDS_SYNC;
+        $records = $DB->get_records_select('tool_objectfs_objects', 'tagsyncstatus = :syncstatus AND location ' . $insql,
+            $inparams, '', 'contenthash', 0, $limit);
+        return array_column($records, 'contenthash');
+    }
+
+    /**
+     * Marks a given object as the given status.
+     * @param string $contenthash
+     * @param int $status one of SYNC_STATUS_* constants
+     * @param int $tagpushedtime if tags were actually sent to the external store,
+     * this should be the time that happened, or zero if not.
+     */
+    public static function mark_object_tag_sync_status(string $contenthash, int $status, int $tagpushedtime = 0) {
+        global $DB;
+        if (!in_array($status, self::SYNC_STATUSES)) {
+            throw new coding_exception("Invalid object tag sync status " . $status);
+        }
+
+        $timeupdate = !empty($tagpushedtime) ? ',tagslastpushed = :time' : '';
+        $params = [
+            'status' => $status,
+            'contenthash' => $contenthash,
+            'time' => $tagpushedtime,
+        ];
+
+        // Need raw execute since update_records requires an id column, but we use contenthash instead.
+        $DB->execute("UPDATE {tool_objectfs_objects}
+                         SET tagsyncstatus = :status
+                         {$timeupdate}
+                       WHERE contenthash = :contenthash",
+                       $params);
+    }
+
+    /**
+     * Returns a simple list of all the sources and their descriptions.
+     * @return string html string
+     */
+    public static function get_tag_source_summary_html(): string {
+        $sources = self::get_defined_tag_sources();
+        $table = new html_table();
+        $table->head = [
+            get_string('table:tagsource', 'tool_objectfs'),
+            get_string('table:tagsourcemeaning', 'tool_objectfs'),
+        ];
+
+        foreach ($sources as $source) {
+            $table->data[$source->get_identifier()] = [$source->get_identifier(), $source->get_description()];
+        }
+        return html_writer::table($table);
+    }
+
+    /**
+     * If the current env is allowed to overwrite tags on objects that already have tags.
+     * @return bool
+     */
+    public static function can_overwrite_object_tags(): bool {
+        return (bool) get_config('tool_objectfs', 'overwriteobjecttags');
+    }
+
+    /**
+     * Get the string for a given tag sync status
+     * @param int $tagsyncstatus one of SYNC_STATUS_*
+     * @return string
+     */
+    public static function get_sync_status_string(int $tagsyncstatus): string {
+        $strmap = [
+            self::SYNC_STATUS_ERROR => 'error',
+            self::SYNC_STATUS_NEEDS_SYNC => 'needssync',
+            self::SYNC_STATUS_COMPLETE => 'notrequired',
+        ];
+
+        if (!array_key_exists($tagsyncstatus, $strmap)) {
+            throw new coding_exception('No status string is mapped for status: ' . $tagsyncstatus);
+        }
+
+        return get_string('tagsyncstatus:' . $strmap[$tagsyncstatus], 'tool_objectfs');
+    }
+
+    /**
+     * Returns a summary of the object tag sync statuses.
+     * Note on larger sites, this can be quite computationally difficult and should be used carefully.
+     * @return array
+     */
+    public static function get_tag_sync_status_summary(): array {
+        global $DB;
+        return $DB->get_records_sql("SELECT tagsyncstatus, COUNT(tagsyncstatus) as statuscount
+                                       FROM {tool_objectfs_objects}
+                                   GROUP BY tagsyncstatus");
+    }
+
+    /**
+     * This is a lightweight check to just check if any objects are reporting tag sync errors.
+     * @return bool
+     */
+    public static function tag_sync_errors_exist(): bool {
+        global $DB;
+        return $DB->record_exists('tool_objectfs_objects', ['tagsyncstatus' => self::SYNC_STATUS_ERROR]);
+    }
+}

--- a/classes/local/tag/tag_source.php
+++ b/classes/local/tag/tag_source.php
@@ -1,0 +1,50 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\local\tag;
+
+/**
+ * Tag source interface
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+interface tag_source {
+    /**
+     * Returns an unchanging identifier for this source.
+     * Must never change, otherwise it will lose connection with the tags replicated to objects.
+     * If it ever must change, a migration step must be completed to trigger all objects to recalculate their tags.
+     * Must not exceed 128 chars.
+     * @return string
+     */
+    public static function get_identifier(): string;
+
+    /**
+     * Description for source displayed in the admin settings.
+     * @return string
+     */
+    public static function get_description(): string;
+
+    /**
+     * Returns the value of this tag for the file with the given content hash.
+     * This must be deterministic, and should never exceed 128 chars.
+     * @param string $contenthash
+     * @return string
+     */
+    public function get_value_for_contenthash(string $contenthash): ?string;
+}

--- a/classes/local/tag_sync_count_result.php
+++ b/classes/local/tag_sync_count_result.php
@@ -1,0 +1,55 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\local;
+
+use core\check\result;
+use html_table;
+use html_writer;
+use tool_objectfs\local\tag\tag_manager;
+
+/**
+ * Tagging sync count result
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tag_sync_count_result extends result {
+    /**
+     * Returns the details, which is a table that displays the count for each object status possibility.
+     * On larger sites, this can take several seconds to execute.
+     * @return string
+     */
+    public function get_details(): string {
+        $statuses = tag_manager::get_tag_sync_status_summary();
+        $table = new html_table();
+        $table->head = [
+            get_string('table:status', 'tool_objectfs'),
+            get_string('table:objectcount', 'tool_objectfs'),
+        ];
+
+        foreach (tag_manager::SYNC_STATUSES as $status) {
+            // If no objects have a status, they won't appear in the SQL above.
+            // In this case, just show zero (so the use knows it exists, but is zero).
+            $count = isset($statuses[$status]->statuscount) ? $statuses[$status]->statuscount : 0;
+            $table->data[$status] = [tag_manager::get_sync_status_string($status), $count];
+        }
+        $table = html_writer::table($table);
+        return $table;
+    }
+}

--- a/classes/task/trigger_update_object_tags.php
+++ b/classes/task/trigger_update_object_tags.php
@@ -1,0 +1,55 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\task;
+
+use core\task\manager;
+use core\task\scheduled_task;
+
+/**
+ * Queues update_object_tags adhoc task periodically, or manually from the frontend.
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class trigger_update_object_tags extends scheduled_task {
+    /**
+     * Task name
+     */
+    public function get_name() {
+        return get_string('task:triggerupdateobjecttags', 'tool_objectfs');
+    }
+    /**
+     * Execute task
+     */
+    public function execute() {
+        // Only schedule up to the max amount, less any that are already scheduled.
+        $alreadyexist = count(manager::get_adhoc_tasks(update_object_tags::class));
+        $maxtoschedule = get_config('tool_objectfs', 'maxtaggingtaskstospawn');
+        $toschedule = max(0, $maxtoschedule - $alreadyexist);
+
+        for ($i = 0; $i < $toschedule; $i++) {
+            // Queue adhoc task, nothing else.
+            $task = new update_object_tags();
+            $task->set_custom_data([
+                'iteration' => 1,
+            ]);
+            manager::queue_adhoc_task($task);
+        }
+    }
+}

--- a/classes/task/update_object_tags.php
+++ b/classes/task/update_object_tags.php
@@ -1,0 +1,124 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\task;
+
+use coding_exception;
+use core\task\adhoc_task;
+use core\task\manager;
+use html_table;
+use html_writer;
+use moodle_exception;
+use tool_objectfs\local\tag\tag_manager;
+
+/**
+ * Calculates and updates an objects tags in the external store.
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class update_object_tags extends adhoc_task {
+    /**
+     * Returns a status badge depending on the health of the task
+     * @return string
+     */
+    public function get_status_badge(): string {
+        $identifier = '';
+        $class = '';
+
+        if ($this->get_fail_delay() > 0) {
+            $identifier = 'failing';
+            $class = 'badge-warning';
+        } else if (!is_null($this->get_timestarted()) && $this->get_timestarted() > 0) {
+            $identifier = 'running';
+            $class = 'badge-info';
+        } else {
+            $identifier = 'waiting';
+            $class = 'badge-info';
+        }
+
+        return html_writer::span(get_string('status:'.$identifier, 'tool_objectfs', $this->get_fail_delay()), 'badge ' . $class);
+    }
+
+    /**
+     * Returns iteration count
+     * @return int
+     */
+    public function get_iteration(): int {
+        return !empty($this->get_custom_data()->iteration) ? $this->get_custom_data()->iteration : 0;
+    }
+
+    /**
+     * Execute task
+     */
+    public function execute() {
+        if (!tag_manager::is_tagging_enabled_and_supported()) {
+            // Site admin should know if this migration is running but the fs doesn't support tagging
+            // (maybe they changed fs mid-run?).
+            throw new moodle_exception('tagging:migration:notsupported', 'tool_objectfs');
+        }
+
+        // Since this adhoc task can requeue itself, ensure there is a fixed limit on the number
+        // of times this can happen, to avoid any accidental runaways.
+        $iterationlimit = get_config('tool_objectfs', 'maxtaggingiterations') ?: 0;
+        $iteration = $this->get_iteration();
+
+        if (empty($iterationlimit) || empty($iteration) || $iterationlimit < 0 || $iteration < 0) {
+            // This should never hit here, if it does something is very wrong.
+            // Throw exception so it causes a retry and alerts.
+            throw new moodle_exception('tagging:migration:invaliditerations', 'tool_objectfs');
+        }
+
+        if ($iteration > $iterationlimit) {
+            // Generally this means the site has too many objects or not enough configured iterations.
+            // Regardless it should throw an exception to get the site admins attention.
+            throw new moodle_exception('tagging:migration:limitreached', 'tool_objectfs', '', $iteration);
+        }
+
+        $fs = get_file_storage()->get_file_system();
+
+        // This is checked above in tag_manager::is_tagging_enabled_and_supported, but as a sanity check
+        // ensure this specific method is defined.
+        if (!method_exists($fs, "push_object_tags")) {
+            throw new coding_exception("Filesystem does not define push_object_tags");
+        }
+
+        // Get the maximum num of objects to update as configured.
+        $limit = get_config('tool_objectfs', 'maxtaggingperrun');
+        $contenthashes = tag_manager::get_objects_needing_sync($limit);
+
+        if (empty($contenthashes)) {
+            // This is ok, it means we are done. Exit silently.
+            mtrace("No more objects found that need tagging, exiting.");
+            return;
+        }
+
+        // For each, try to sync their tags.
+        foreach ($contenthashes as $contenthash) {
+            $fs->push_object_tags($contenthash);
+        }
+
+        // Re-queue self to process more in another iteration.
+        mtrace("Requeing self for another iteration.");
+        $task = new update_object_tags();
+        $task->set_custom_data([
+            'iteration' => $iteration + 1,
+        ]);
+        \core\task\manager::queue_adhoc_task($task);
+    }
+}

--- a/classes/tests/test_client.php
+++ b/classes/tests/test_client.php
@@ -16,6 +16,7 @@
 
 namespace tool_objectfs\tests;
 
+use coding_exception;
 use tool_objectfs\local\store\object_client_base;
 
 /**
@@ -36,6 +37,11 @@ class test_client extends object_client_base {
      * @var string
      */
     private $bucketpath;
+
+    /**
+     * @var array in-memory tags used for unit tests
+     */
+    public $tags;
 
     /**
      * string
@@ -168,6 +174,37 @@ class test_client extends object_client_base {
     public function get_token_expiry_time(): int {
         global $CFG;
         return $CFG->objectfs_phpunit_token_expiry_time;
+    }
+
+    /**
+     * Sets object tags - uses in-memory store for unit tests
+     * @param string $contenthash
+     * @param array $tags
+     */
+    public function set_object_tags(string $contenthash, array $tags) {
+        global $CFG;
+        if (!empty($CFG->phpunit_objectfs_simulate_tag_set_error)) {
+            throw new coding_exception("Simulated tag set error");
+        }
+        $this->tags[$contenthash] = $tags;
+    }
+
+    /**
+     * Gets object tags - uses in-memory store for unit tests
+     * @param string $contenthash
+     * @return array
+     */
+    public function get_object_tags(string $contenthash): array {
+        return $this->tags[$contenthash] ?? [];
+    }
+
+    /**
+     * Object tagging support, for unit testing
+     * @return bool
+     */
+    public function supports_object_tagging(): bool {
+        global $CFG;
+        return $CFG->phpunit_objectfs_supports_object_tagging;
     }
 }
 

--- a/classes/tests/testcase.php
+++ b/classes/tests/testcase.php
@@ -33,7 +33,6 @@ use tool_objectfs\local\store\signed_url;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 abstract class testcase extends \advanced_testcase {
-
     /** @var test_file_system Filesystem */
     public $filesystem;
 
@@ -48,9 +47,33 @@ abstract class testcase extends \advanced_testcase {
         global $CFG;
         $CFG->alternative_file_system_class = '\\tool_objectfs\\tests\\test_file_system';
         $CFG->forced_plugin_settings['tool_objectfs']['deleteexternal'] = false;
+        set_config('taggingenvironment', 'test', 'tool_objectfs');
         $this->filesystem = new test_file_system();
         $this->logger = new \tool_objectfs\log\null_logger();
+
+        // Get the file system with reset flag enabled to reset it,
+        // since it is static and may have been initialised as a filedir system in another test
+        // instead of the desired objectfs test file system.
+        get_file_storage(true);
+
         $this->resetAfterTest(true);
+    }
+
+    /**
+     * Enables the test object filesystem and sets the tagging value.
+     * @param bool $tagging if tagging should be enabled or not.
+     */
+    protected function enable_filesystem_and_set_tagging(bool $tagging) {
+        global $CFG;
+        set_config('taggingenabled', $tagging, 'tool_objectfs');
+
+        // Set supported by fs.
+        $config = manager::get_objectfs_config();
+        $config->taggingenabled = $tagging;
+        $config->enabletasks = true;
+        $config->filesystem = '\\tool_objectfs\\tests\\test_file_system';
+        manager::set_objectfs_config($config);
+        $CFG->phpunit_objectfs_supports_object_tagging = $tagging;
     }
 
     /**

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="admin/tool/objectfs/db" VERSION="20161207" COMMENT="XMLDB file for Moodle tool/objectfs plugin"
+<XMLDB PATH="admin/tool/objectfs/db" VERSION="20240719" COMMENT="XMLDB file for Moodle tool/objectfs plugin"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
 >
@@ -11,6 +11,8 @@
         <FIELD NAME="timeduplicated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="location" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="filesize" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="tagsyncstatus" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="tagslastpushed" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="contenthash" TYPE="unique" FIELDS="contenthash"/>
@@ -37,7 +39,7 @@
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="reportid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="reporttype" TYPE="char" LENGTH="15" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="datakey" TYPE="char" LENGTH="15" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="datakey" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="objectcount" TYPE="int" LENGTH="15" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="objectsum" TYPE="int" LENGTH="20" NOTNULL="true" SEQUENCE="false"/>
       </FIELDS>
@@ -47,6 +49,20 @@
       <INDEXES>
         <INDEX NAME="reportid_idx" UNIQUE="false" FIELDS="reportid"/>
         <INDEX NAME="reporttype_idx" UNIQUE="false" FIELDS="reporttype"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="tool_objectfs_object_tags" COMMENT="Object tag key value pairs">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="objectid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="tagkey" TYPE="char" LENGTH="32" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="tagvalue" TYPE="char" LENGTH="128" NOTNULL="true" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="objecttagkey_idx" UNIQUE="true" FIELDS="objectid, tagkey"/>
       </INDEXES>
     </TABLE>
   </TABLES>

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -107,5 +107,17 @@ $tasks = [
         'dayofweek' => '*',
         'month'     => '*',
     ],
+    [
+        'classname' => 'tool_objectfs\task\trigger_update_object_tags',
+        'blocking'  => 0,
+        'minute'    => 'R',
+        'hour'      => '*',
+        'day'       => '*',
+        'dayofweek' => '*',
+        'month'     => '*',
+        // Default disabled - intended to be manually run.
+        // Also, objectfs tagging support is default off.
+        'disabled' => true,
+    ],
 ];
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -170,5 +170,58 @@ function xmldb_tool_objectfs_upgrade($oldversion) {
 
         upgrade_plugin_savepoint(true, 2023013100, 'tool', 'objectfs');
     }
+
+    if ($oldversion < 2024120600) {
+
+        // Define table tool_objectfs_object_tags to be created.
+        $table = new xmldb_table('tool_objectfs_object_tags');
+
+        // Adding fields to table tool_objectfs_object_tags.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('objectid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('tagkey', XMLDB_TYPE_CHAR, '32', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('tagvalue', XMLDB_TYPE_CHAR, '128', null, XMLDB_NOTNULL, null, null);
+
+        // Adding keys to table tool_objectfs_object_tags.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        // Adding indexes to table tool_objectfs_object_tags.
+        $table->add_index('objecttagkey_idx', XMLDB_INDEX_UNIQUE, ['objectid', 'tagkey']);
+
+        // Conditionally launch create table for tool_objectfs_object_tags.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Define field tagsyncstatus to be added to tool_objectfs_objects.
+        $table = new xmldb_table('tool_objectfs_objects');
+        $field = new xmldb_field('tagsyncstatus', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '0', 'filesize');
+
+        // Conditionally launch add field tagsyncstatus.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Changing precision of field datakey on table tool_objectfs_report_data,
+        // to (255) to allow for tag key + value pairs to fit in.
+        $table = new xmldb_table('tool_objectfs_report_data');
+        $field = new xmldb_field('datakey', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null, 'reporttype');
+
+        // Launch change of precision for field datakey.
+        $dbman->change_field_precision($table, $field);
+
+        // Define field tagslastpushed to be added to tool_objectfs_objects.
+        $table = new xmldb_table('tool_objectfs_objects');
+        $field = new xmldb_field('tagslastpushed', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, 0, 'tagsyncstatus');
+
+        // Conditionally launch add field tagslastpushed.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Objectfs savepoint reached.
+        upgrade_plugin_savepoint(true, 2024120600, 'tool', 'objectfs');
+    }
+
     return true;
 }

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -275,3 +275,62 @@ $string['check:tokenexpiry:expiresin'] = 'Token expires in {$a->dayssince} days 
 $string['check:tokenexpiry:expired'] = 'Token expired for {$a->dayssince} days. Expired on {$a->time}';
 $string['check:tokenexpiry:na'] = 'Token expiry check not implemented for filesystem, or no token is set';
 $string['settings:tokenexpirywarnperiod'] = 'Token expiry warn period';
+
+$string['settings:taggingenvironment'] = 'Tagging environment';
+$string['settings:taggingenvironment:desc'] = 'The \'environment\' tag value. Used to distinguish the source of objects when multiple environments share a single bucket.';
+$string['settings:taggingheader'] = 'Tagging settings';
+$string['settings:taggingenabled'] = 'Tagging enabled';
+$string['settings:maxtaggingperrun'] = 'Object tagging adhoc sync maximum objects per run';
+$string['settings:maxtaggingperrun:desc'] = 'The maximum number of objects to sync tags for per tagging sync adhoc task iteration.';
+$string['settings:maxtaggingiterations'] = 'Object tagging adhoc sync maximum number of iterations ';
+$string['settings:maxtaggingiterations:desc'] = 'The maximum number of times the tagging sync adhoc task will requeue itself. To avoid accidental infinite runaway.';
+$string['settings:maxtaggingtaskstospawn'] = 'Maximum number of parallel tagging migration tasks';
+$string['settings:maxtaggingtaskstospawn:desc'] = 'Each trigger of the scheduled task `trigger_update_object_tags` will spawn this amount of tasks, minus those that are already running.';
+$string['settings:overrideobjecttags'] = 'Allow object tag override';
+$string['settings:overrideobjecttags:desc'] = 'Allows ObjectFS to overwrite tags on objects that already exist in the external store. If not checked, objectfs will only set tags when the objects "environment" value is empty or is the same as currently defined.';
+$string['settings:tagsources'] = 'Tag sources';
+$string['settings:taggingstatus'] = 'Tagging status';
+$string['settings:taggingstatuscounts'] = 'Tag sync status overview';
+$string['settings:taggingmigrationstatus'] = 'Tagging adhoc migration progress';
+$string['settings:tagging:help'] = 'Object tagging allows extra metadata to be attached to objects in the external store. Please read TAGGING.md in the plugin Github repository for detailed setup and considerations. This is currently only supported by the S3 external client.';
+
+$string['checktagging_status'] = 'Object tagging';
+$string['checktagging_sync_status'] = 'Object tagging sync status';
+$string['checktagging_migration_status'] = 'Object tagging migration status';
+
+$string['check:tagging:ok'] = 'Object tagging ok';
+$string['check:tagging:syncerror'] = 'Objects have tag sync errors';
+$string['check:tagging:syncok'] = 'No objects reporting sync errors';
+$string['check:tagging:migrationerror'] = 'Object tagging migration task(s) have faildelay > 0';
+$string['check:tagging:migrationok'] = 'Object tagging migration tasks OK';
+$string['check:tagging:na'] = 'Tagging not enabled or is not supported by file system';
+$string['check:tagging:error'] = 'Error trying to tag object';
+
+$string['tagsource:environment'] = 'Environment defined by the "taggingenvironment" setting, currently: "{$a}".';
+$string['tagsource:environment:toolong'] = 'The value defined in objectfs_environment_name is too long. It must be < 128 chars';
+$string['tagsource:location'] = 'Location of file, either "orphan" or "active".';
+
+$string['task:triggerupdateobjecttags'] = 'Queue adhoc task to update object tags';
+
+$string['tagsyncstatus:error'] = 'Errored';
+$string['tagsyncstatus:notrequired'] = 'Not required / synced';
+$string['tagsyncstatus:needssync'] = 'Waiting for sync';
+
+$string['tagging:migration:notsupported'] = 'Tagging not enabled or supported by filesystem. Cannot execute tag migration task';
+$string['tagging:migration:invaliditerations'] = 'Invalid iteration number or iteration count';
+$string['tagging:migration:limitreached'] = 'Current iteration {$a} is >= the maximum number of iterations. Please investigate if this is expected and you need to increase the limit, or if there is a problem syncing the tags causing an infinite loop';
+$string['tagging:migration:nothingrunning'] = 'No tagging migration adhoc tasks are currently running';
+$string['tagging:migration:help'] = 'Run the <code>trigger_update_object_tags</code> scheduled task from the frontend or CLI to start a migration task.';
+
+$string['table:taskid'] = 'Task ID';
+$string['table:iteration'] = 'Iteration number';
+$string['table:status'] = 'Status';
+$string['table:objectcount'] = 'Object count';
+$string['table:tagsource'] = 'Tag source';
+$string['table:tagsourcemeaning'] = 'Description';
+
+$string['status:waiting'] = 'Waiting';
+$string['status:running'] = 'Running';
+$string['status:failing'] = 'Faildelay {$a}';
+
+$string['object_status:tag_count'] = 'Object tags';

--- a/lib.php
+++ b/lib.php
@@ -24,6 +24,7 @@
  */
 
 use tool_objectfs\local\object_manipulator\manipulator_builder;
+use tool_objectfs\local\tag\tag_manager;
 
 define('OBJECTFS_PLUGIN_NAME', 'tool_objectfs');
 
@@ -103,6 +104,9 @@ function tool_objectfs_pluginfile($course, $cm, context $context, $filearea, arr
 function tool_objectfs_status_checks() {
     $checks = [
         new tool_objectfs\check\token_expiry(),
+        new tool_objectfs\check\tagging_status(),
+        new tool_objectfs\check\tagging_sync_status(),
+        new tool_objectfs\check\tagging_migration_status(),
     ];
 
     if (get_config('tool_objectfs', 'proxyrangerequests')) {

--- a/object_status.php
+++ b/object_status.php
@@ -57,6 +57,9 @@ if ($reports = objectfs_report::get_report_ids()) {
         echo $OUTPUT->box_start();
         $table = new object_status_history_table($reporttype, $reportid);
         $table->baseurl = $pageurl;
+
+        $heading = get_string('object_status:' . $reporttype, 'tool_objectfs');
+        echo $OUTPUT->heading($heading, 2);
         $table->out(0, false);
         echo $OUTPUT->box_end();
     }

--- a/settings.php
+++ b/settings.php
@@ -24,6 +24,9 @@
  */
 
 use tool_objectfs\check\token_expiry;
+use tool_objectfs\check\tagging_migration_status;
+use tool_objectfs\check\tagging_sync_status;
+use tool_objectfs\local\tag\tag_manager;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -130,7 +133,6 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_configduration('tool_objectfs/consistencydelay',
         new lang_string('settings:consistencydelay', 'tool_objectfs'), '', 10 * MINSECS, MINSECS));
-
 
     $settings->add(new admin_setting_heading('tool_objectfs/storagefilesystemselection',
         new lang_string('settings:clientselection:header', 'tool_objectfs'), ''));
@@ -267,4 +269,72 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_configcheckbox('tool_objectfs/preferexternal',
         new lang_string('settings:preferexternal', 'tool_objectfs'), '', ''));
+
+    // Tagging settings.
+    $settings->add(new admin_setting_heading('tool_objectfs/taggingsettings',
+        new lang_string('settings:taggingheader', 'tool_objectfs'),
+        get_string('settings:tagging:help', 'tool_objectfs')
+    ));
+
+    $settings->add(new admin_setting_configcheckbox('tool_objectfs/taggingenabled',
+        new lang_string('settings:taggingenabled', 'tool_objectfs'), '', 0));
+
+    $settings->add(new admin_setting_configtext('tool_objectfs/taggingenvironment',
+        new lang_string('settings:taggingenvironment', 'tool_objectfs'),
+        get_string('settings:taggingenvironment:desc', 'tool_objectfs'),
+        '',
+        PARAM_TEXT
+    ));
+
+    $settings->add(new admin_setting_description('tool_objectfs/tagsources',
+        new lang_string('settings:tagsources', 'tool_objectfs'),
+        tag_manager::get_tag_source_summary_html()
+    ));
+
+    $settings->add(new admin_setting_configtext('tool_objectfs/maxtaggingperrun',
+        new lang_string('settings:maxtaggingperrun', 'tool_objectfs'),
+        get_string('settings:maxtaggingperrun:desc', 'tool_objectfs'),
+        1000,
+        PARAM_INT
+    ));
+
+    $settings->add(new admin_setting_configtext('tool_objectfs/maxtaggingiterations',
+        new lang_string('settings:maxtaggingiterations', 'tool_objectfs'),
+        get_string('settings:maxtaggingiterations:desc', 'tool_objectfs'),
+        10000,
+        PARAM_INT
+    ));
+
+    $settings->add(new admin_setting_configtext('tool_objectfs/maxtaggingtaskstospawn',
+        new lang_string('settings:maxtaggingtaskstospawn', 'tool_objectfs'),
+        get_string('settings:maxtaggingtaskstospawn:desc', 'tool_objectfs'),
+        1,
+        PARAM_INT
+    ));
+
+    $settings->add(new admin_setting_configcheckbox('tool_objectfs/overwriteobjecttags',
+        new lang_string('settings:overrideobjecttags', 'tool_objectfs'),
+        get_string('settings:overrideobjecttags:desc', 'tool_objectfs'),
+        1
+    ));
+
+    // Tagging status.
+    $settings->add(new admin_setting_heading('tool_objectfs/taggingstatus',
+        new lang_string('settings:taggingstatus', 'tool_objectfs'), ''));
+
+    // Only in 4.4+.
+    if (class_exists('admin_setting_check')) {
+        $settings->add(new admin_setting_check('tool_objectfs/check_taggingsyncstatus', new tagging_sync_status(), true));
+        $settings->add(new admin_setting_check('tool_objectfs/check_taggingmigrationstatus', new tagging_migration_status(), true));
+    } else {
+        // Fallback to links instead.
+        $settings->add(new admin_setting_description('taggingstatuslink', '', html_writer::link(
+            new moodle_url('/report/status/index.php', ['detail' => 'tool_objectfs_tagging_sync_status']),
+            get_string('settings:taggingstatus', 'tool_objectfs')
+        )));
+        $settings->add(new admin_setting_description('taggingmigrationstatuslink', '', html_writer::link(
+            new moodle_url('/report/status/index.php', ['detail' => 'tool_objectfs_tagging_migration_status']),
+            get_string('settings:taggingmigrationstatus', 'tool_objectfs')
+        )));
+    }
 }

--- a/tests/check/tagging_migration_status_test.php
+++ b/tests/check/tagging_migration_status_test.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\check;
+
+use core\check\result;
+use core\task\manager;
+use tool_objectfs\check\tagging_migration_status;
+use tool_objectfs\task\update_object_tags;
+use tool_objectfs\tests\testcase;
+
+/**
+ * Tagging migration status check tests
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \tool_objectfs\check\tagging_migration_status
+ */
+class tagging_migration_status_test extends testcase {
+    /**
+     * Tests scenario that returns N/A
+     */
+    public function test_get_result_na() {
+        // Regardless if this is disabled, the check should still return a non n/a status.
+        $this->enable_filesystem_and_set_tagging(false);
+        $check = new tagging_migration_status();
+        $this->assertEquals(result::NA, $check->get_result()->get_status());
+    }
+
+    /*
+     * Test scenario that returns WARNING
+     */
+    public function test_get_result_warning() {
+        // Regardless if this is disabled, the check should still return a non n/a status.
+        $this->enable_filesystem_and_set_tagging(false);
+
+        $task = new update_object_tags();
+        $task->set_fail_delay(64);
+        manager::queue_adhoc_task($task);
+
+        $check = new tagging_migration_status();
+        $this->assertEquals(result::WARNING, $check->get_result()->get_status());
+    }
+
+    /*
+     * Test scenario that returns OK
+     */
+    public function test_get_result_ok() {
+        // Regardless if this is disabled, the check should still return a non n/a status.
+        $this->enable_filesystem_and_set_tagging(false);
+
+        $task = new update_object_tags();
+        manager::queue_adhoc_task($task);
+
+        $check = new tagging_migration_status();
+        $this->assertEquals(result::OK, $check->get_result()->get_status());
+    }
+}

--- a/tests/check/tagging_sync_status_test.php
+++ b/tests/check/tagging_sync_status_test.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\check;
+
+use core\check\result;
+use tool_objectfs\check\tagging_sync_status;
+use tool_objectfs\local\tag\tag_manager;
+use tool_objectfs\tests\testcase;
+
+/**
+ * Tagging sync status check tests
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \tool_objectfs\check\tagging_sync_status
+ */
+class tagging_sync_status_test extends testcase {
+    /**
+     * Tests scenario that returns N/A
+     */
+    public function test_get_result_na() {
+        // Not enabled by default, should return N/A.
+        $check = new tagging_sync_status();
+        $this->assertEquals(result::NA, $check->get_result()->get_status());
+    }
+
+    /**
+     * Test scenario that returns OK
+     */
+    public function test_get_result_ok() {
+        $this->enable_filesystem_and_set_tagging(true);
+        $object = $this->create_remote_object();
+        tag_manager::mark_object_tag_sync_status($object->contenthash, tag_manager::SYNC_STATUS_COMPLETE);
+
+        // All objects OK, should return ok.
+        $check = new tagging_sync_status();
+        $this->assertEquals(result::OK, $check->get_result()->get_status());
+    }
+
+    /**
+     * Tests scenario that returns WARNING
+     */
+    public function test_get_result_warning() {
+        $this->enable_filesystem_and_set_tagging(true);
+        $object = $this->create_remote_object();
+        tag_manager::mark_object_tag_sync_status($object->contenthash, tag_manager::SYNC_STATUS_ERROR);
+
+        // An object has error, should return warning.
+        $check = new tagging_sync_status();
+        $this->assertEquals(result::WARNING, $check->get_result()->get_status());
+    }
+}

--- a/tests/local/report/object_status_test.php
+++ b/tests/local/report/object_status_test.php
@@ -66,7 +66,7 @@ class object_status_test extends \tool_objectfs\tests\testcase {
     public function test_get_report_types() {
         $reporttypes = objectfs_report::get_report_types();
         $this->assertEquals('array', gettype($reporttypes));
-        $this->assertEquals(3, count($reporttypes));
+        $this->assertEquals(4, count($reporttypes));
     }
 
     /**

--- a/tests/local/tagging_test.php
+++ b/tests/local/tagging_test.php
@@ -1,0 +1,442 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\local;
+
+use coding_exception;
+use moodle_exception;
+use Throwable;
+use tool_objectfs\local\manager;
+use tool_objectfs\local\tag\environment_source;
+use tool_objectfs\local\tag\tag_manager;
+use tool_objectfs\local\tag\tag_source;
+use tool_objectfs\tests\test_client;
+use tool_objectfs\tests\testcase;
+
+/**
+ * Tests tagging
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tagging_test extends testcase {
+    /**
+     * Tests get_defined_tag_sources
+     * @covers \tool_objectfs\local\tag_manager::get_defined_tag_sources
+     */
+    public function test_get_defined_tag_sources() {
+        $sources = tag_manager::get_defined_tag_sources();
+        $this->assertIsArray($sources);
+
+        // Both AWS and Azure limit 10 tags per object, so ensure never more than 10 sources defined.
+        $this->assertLessThanOrEqual(10, count($sources));
+    }
+
+    /**
+     * Provides values to various tag source tests
+     * @return array
+     */
+    public static function tag_source_provider(): array {
+        $sources = tag_manager::get_defined_tag_sources();
+        $tests = [];
+
+        foreach ($sources as $source) {
+            $tests[$source->get_identifier()] = [
+                'source' => $source,
+            ];
+        }
+
+        return $tests;
+    }
+
+    /**
+     * Tests the source identifier
+     * @param tag_source $source
+     * @dataProvider tag_source_provider
+     * @covers \tool_objectfs\local\tag_source::get_identifier
+     */
+    public function test_tag_sources_identifier(tag_source $source) {
+        $count = strlen($source->get_identifier());
+
+        // Ensure < 32 chars, the max length as defined in our docs.
+        $this->assertLessThan(32, $count);
+        $this->assertGreaterThan(0, $count);
+    }
+
+    /**
+     * Tests the source value
+     * @param tag_source $source
+     * @dataProvider tag_source_provider
+     * @covers \tool_objectfs\local\tag_source::get_value_for_contenthash
+     */
+    public function test_tag_sources_value(tag_source $source) {
+        $file = $this->create_duplicated_object('tag source value test ' . $source->get_identifier());
+        $value = $source->get_value_for_contenthash($file->contenthash);
+
+        // Null value - allowed, but means we cannot test.
+        if (is_null($value)) {
+            return;
+        }
+
+        $count = strlen($value);
+
+        // Ensure < 128 chars, the max length as defined in our docs.
+        $this->assertLessThan(128, $count);
+        $this->assertGreaterThan(0, $count);
+    }
+
+    /**
+     * Provides values to test_is_tagging_enabled_and_supported
+     * @return array
+     */
+    public static function is_tagging_enabled_and_supported_provider(): array {
+        return [
+            'neither config nor fs supports' => [
+                'enabledinconfig' => false,
+                'supportedbyfs' => false,
+                'expected' => false,
+            ],
+            'enabled in config but fs does not support' => [
+                'enabledinconfig' => true,
+                'supportedbyfs' => false,
+                'expected' => false,
+            ],
+            'enabled in config and fs does support' => [
+                'enabledinconfig' => true,
+                'supportedbyfs' => true,
+                'expected' => true,
+            ],
+        ];
+    }
+
+    /**
+     * Tests is_tagging_enabled_and_supported
+     * @param bool $enabledinconfig if tagging feature is turned on
+     * @param bool $supportedbyfs if the filesystem supports tagging
+     * @param bool $expected expected return result
+     * @dataProvider is_tagging_enabled_and_supported_provider
+     * @covers \tool_objectfs\local\tag_manager::is_tagging_enabled_and_supported
+     */
+    public function test_is_tagging_enabled_and_supported(bool $enabledinconfig, bool $supportedbyfs, bool $expected) {
+        global $CFG;
+        // Set config.
+        set_config('taggingenabled', $enabledinconfig, 'tool_objectfs');
+
+        // Set supported by fs.
+        $config = manager::get_objectfs_config();
+        $config->taggingenabled = $enabledinconfig;
+        $config->enabletasks = true;
+        $config->filesystem = '\\tool_objectfs\\tests\\test_file_system';
+        manager::set_objectfs_config($config);
+        $CFG->phpunit_objectfs_supports_object_tagging = $supportedbyfs;
+
+        $this->assertEquals($expected, tag_manager::is_tagging_enabled_and_supported());
+    }
+
+    /**
+     * Tests gather_object_tags_for_upload
+     * @covers \tool_objectfs\local\tag_manager::gather_object_tags_for_upload
+     */
+    public function test_gather_object_tags_for_upload() {
+        $object = $this->create_duplicated_object('gather tags for upload test');
+        $tags = tag_manager::gather_object_tags_for_upload($object->contenthash);
+
+        $this->assertArrayHasKey('environment', $tags);
+        $this->assertEquals('test', $tags['environment']);
+        $this->assertArrayHasKey('location', $tags);
+        $this->assertEquals('active', $tags['location']);
+    }
+
+    /**
+     * Tests gather_object_tags_for_upload when orphaned
+     * @covers \tool_objectfs\local\tag_manager::gather_object_tags_for_upload
+     */
+    public function test_gather_object_tags_for_upload_orphaned() {
+        global $DB;
+        $object = $this->create_duplicated_object('gather tags for upload test');
+
+        // Change the object record to be orphaned.
+        $DB->update_record('tool_objectfs_objects', ['id' => $object->id, 'location' => OBJECT_LOCATION_ORPHANED]);
+
+        $tags = tag_manager::gather_object_tags_for_upload($object->contenthash);
+
+        $this->assertArrayHasKey('environment', $tags);
+        $this->assertEquals('test', $tags['environment']);
+        $this->assertArrayHasKey('location', $tags);
+        $this->assertEquals('orphan', $tags['location']);
+    }
+
+    /**
+     * Tests store_tags_locally
+     * @covers \tool_objectfs\local\tag_manager::store_tags_locally
+     */
+    public function test_store_tags_locally() {
+        global $DB;
+
+        $tags = [
+            'test1' => 'abc',
+            'test2' => 'xyz',
+        ];
+        $object = $this->create_remote_object();
+
+        // Ensure no tags for hash intially.
+        $this->assertEmpty($DB->get_records('tool_objectfs_object_tags', ['objectid' => $object->id]));
+
+        // Store.
+        tag_manager::store_tags_locally($object->contenthash, $tags);
+
+        // Confirm they are stored.
+        $queriedtags = $DB->get_records('tool_objectfs_object_tags', ['objectid' => $object->id]);
+        $this->assertCount(2, $queriedtags);
+    }
+
+    /**
+     * Provides values to test_get_objects_needing_sync
+     * @return array
+     */
+    public static function get_objects_needing_sync_provider(): array {
+        return [
+            'duplicated, needs sync' => [
+                'location' => OBJECT_LOCATION_DUPLICATED,
+                'status' => tag_manager::SYNC_STATUS_NEEDS_SYNC,
+                'expectedneedssync' => true,
+            ],
+            'remote, needs sync' => [
+                'location' => OBJECT_LOCATION_EXTERNAL,
+                'status' => tag_manager::SYNC_STATUS_NEEDS_SYNC,
+                'expectedneedssync' => true,
+            ],
+            'local, needs sync' => [
+                'location' => OBJECT_LOCATION_LOCAL,
+                'status' => tag_manager::SYNC_STATUS_NEEDS_SYNC,
+                'expectedneedssync' => false,
+            ],
+            'duplicated, does not need sync' => [
+                'location' => OBJECT_LOCATION_DUPLICATED,
+                'status' => tag_manager::SYNC_STATUS_COMPLETE,
+                'expectedneedssync' => false,
+            ],
+            'local, does not need sync' => [
+                'location' => OBJECT_LOCATION_LOCAL,
+                'status' => tag_manager::SYNC_STATUS_COMPLETE,
+                'expectedneedssync' => false,
+            ],
+            'duplicated, sync error' => [
+                'location' => OBJECT_LOCATION_DUPLICATED,
+                'status' => tag_manager::SYNC_STATUS_ERROR,
+                'expectedneedssync' => false,
+            ],
+            'local, sync error' => [
+                'location' => OBJECT_LOCATION_LOCAL,
+                'status' => tag_manager::SYNC_STATUS_ERROR,
+                'expectedneedssync' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Tests get_objects_needing_sync
+     * @param int $location object location
+     * @param int $syncstatus sync status to set on object record
+     * @param bool $expectedneedssync if the object should be included in the return of the function
+     * @dataProvider get_objects_needing_sync_provider
+     * @covers \tool_objectfs\local\tag_manager::get_objects_needing_sync
+     */
+    public function test_get_objects_needing_sync(int $location, int $syncstatus, bool $expectedneedssync) {
+        global $DB;
+
+        // Create the test object at the required location.
+        switch ($location) {
+            case OBJECT_LOCATION_DUPLICATED:
+                $object = $this->create_duplicated_object('tagging test object duplicated');
+                break;
+            case OBJECT_LOCATION_LOCAL:
+                $object = $this->create_local_object('tagging test object local');
+                break;
+            case OBJECT_LOCATION_EXTERNAL:
+                $object = $this->create_remote_object('tagging test object remote');
+                break;
+            default:
+                throw new coding_exception("Object location not handled in test");
+        }
+
+        // Set the sync status.
+        $DB->set_field('tool_objectfs_objects', 'tagsyncstatus', $syncstatus, ['id' => $object->id]);
+
+        // Check if it is included in the list.
+        $needssync = tag_manager::get_objects_needing_sync(1);
+
+        if ($expectedneedssync) {
+            $this->assertContains($object->contenthash, $needssync);
+        } else {
+            $this->assertNotContains($object->contenthash, $needssync);
+        }
+    }
+
+    /**
+     * Tests the limit input to get_objects_needing_sync
+     * @covers \tool_objectfs\local\tag_manager::get_objects_needing_sync
+     */
+    public function test_get_objects_needing_sync_limit() {
+        global $DB;
+
+        // Create two duplicated objects needing sync.
+        $object = $this->create_duplicated_object('sync limit test duplicated');
+        $DB->set_field('tool_objectfs_objects', 'tagsyncstatus', tag_manager::SYNC_STATUS_NEEDS_SYNC, ['id' => $object->id]);
+        $object = $this->create_remote_object('sync limit test remote');
+        $DB->set_field('tool_objectfs_objects', 'tagsyncstatus', tag_manager::SYNC_STATUS_NEEDS_SYNC, ['id' => $object->id]);
+
+        // Ensure a limit of 2 returns 2, and limit of 1 returns 1.
+        $this->assertCount(2, tag_manager::get_objects_needing_sync(2));
+        $this->assertCount(1, tag_manager::get_objects_needing_sync(1));
+    }
+
+    /**
+     * Test get_tag_source_summary_html
+     * @covers \tool_objectfs\local\tag_manager::get_tag_source_summary_html
+     */
+    public function test_get_tag_source_summary_html() {
+        // Quick test just to ensure it generates and nothing explodes.
+        $html = tag_manager::get_tag_source_summary_html();
+        $this->assertIsString($html);
+    }
+
+    /**
+     * Tests when fails to sync object tags, that the sync status is updated to SYNC_STATUS_ERROR.
+     * @covers \tool_objectfs\local\tag_manager
+     */
+    public function test_object_tag_sync_error() {
+        global $CFG, $DB;
+
+        // Integration clients won't simulate errors, so we can't test this functionality.
+        if (!$this->filesystem->externalclient instanceof test_client) {
+            $this->markTestSkipped("Cannot test sync error during integration testing");
+            return;
+        }
+
+        // Setup FS for tagging.
+        $config = manager::get_objectfs_config();
+        $config->taggingenabled = true;
+        $config->enabletasks = true;
+        $config->filesystem = '\\tool_objectfs\\tests\\test_file_system';
+        manager::set_objectfs_config($config);
+
+        $CFG->phpunit_objectfs_supports_object_tagging = true;
+        $this->assertTrue(tag_manager::is_tagging_enabled_and_supported());
+
+        // Create a good duplicated object.
+        $object = $this->create_duplicated_object('sync limit test duplicated');
+        $status = $DB->get_field('tool_objectfs_objects', 'tagsyncstatus', ['id' => $object->id]);
+        $this->assertEquals(tag_manager::SYNC_STATUS_COMPLETE, $status);
+
+        // Now try push tags, but trigger a simulated tag set error.
+        $CFG->phpunit_objectfs_simulate_tag_set_error = true;
+        $didthrow = false;
+        try {
+            $this->filesystem->push_object_tags($object->contenthash);
+        } catch (Throwable $e) {
+            $didthrow = true;
+        }
+        $this->assertTrue($didthrow);
+
+        // Ensure tag sync status set to error.
+        $status = $DB->get_field('tool_objectfs_objects', 'tagsyncstatus', ['id' => $object->id]);
+        $this->assertEquals(tag_manager::SYNC_STATUS_ERROR, $status);
+    }
+
+    /**
+     * Tests tag_manger::get_tag_sync_status_summary
+     * @covers \tool_objectfs\local\tag_manager::get_tag_sync_status_summary
+     */
+    public function test_get_tag_sync_status_summary() {
+        // Ensure clean slate before test starts.
+        global $DB;
+        $DB->delete_records('tool_objectfs_objects');
+
+        // Create an object with each status.
+        $object1 = $this->create_local_object('test1');
+        $object2 = $this->create_local_object('test2');
+        $object3 = $this->create_local_object('test3');
+
+        // Delete the unit test object that is automatically created, it has a filesize of zero.
+        $DB->delete_records('tool_objectfs_objects', ['filesize' => 0]);
+
+        tag_manager::mark_object_tag_sync_status($object1->contenthash, tag_manager::SYNC_STATUS_COMPLETE);
+        tag_manager::mark_object_tag_sync_status($object2->contenthash, tag_manager::SYNC_STATUS_ERROR);
+        tag_manager::mark_object_tag_sync_status($object3->contenthash, tag_manager::SYNC_STATUS_NEEDS_SYNC);
+
+        // Ensure correctly counted.
+        $statuses = tag_manager::get_tag_sync_status_summary();
+        $this->assertEquals(1, $statuses[tag_manager::SYNC_STATUS_COMPLETE]->statuscount);
+        $this->assertEquals(1, $statuses[tag_manager::SYNC_STATUS_ERROR]->statuscount);
+        $this->assertEquals(1, $statuses[tag_manager::SYNC_STATUS_NEEDS_SYNC]->statuscount);
+    }
+
+    /**
+     * Provides sync statuses to tests
+     * @return array
+     */
+    public static function sync_status_provider(): array {
+        $tests = [];
+        foreach (tag_manager::SYNC_STATUSES as $status) {
+            $tests[$status] = [
+                'status' => $status,
+            ];
+        }
+        return $tests;
+    }
+
+    /**
+     * Tests get_sync_status_string
+     * @param int $status
+     * @dataProvider sync_status_provider
+     * @covers \tool_objectfs\local\tag_manager::get_sync_status_string
+     */
+    public function test_get_sync_status_string(int $status) {
+        $string = tag_manager::get_sync_status_string($status);
+        // Cheap check to ensure placeholder string not returned.
+        $this->assertStringNotContainsString('[', $string);
+    }
+
+    /**
+     * Tests get_sync_status_string when an invalid status is provided
+     * @covers \tool_objectfs\local\tag_manager::get_sync_status_string
+     */
+    public function test_get_sync_status_string_does_not_exist() {
+        $this->expectException(coding_exception::class);
+        $this->expectExceptionMessage('No status string is mapped for status: 5');
+        tag_manager::get_sync_status_string(5);
+    }
+
+    /**
+     * Tests the length of the defined tag source is checked correctly
+     * @covers \tool_objectfs\local\environment_source
+     */
+    public function test_environment_source_too_long() {
+        global $CFG;
+        set_config('taggingenvironment', 'This is a really long string.
+            It needs to be long because it needs to be more than 128 chars for the test to trigger an exception.',
+            'tool_objectfs');
+
+        $source = new environment_source();
+
+        $this->expectException(moodle_exception::class);
+        $this->expectExceptionMessage(get_string('tagsource:environment:toolong', 'tool_objectfs'));
+        $source->get_value_for_contenthash('test');
+    }
+}

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -16,8 +16,11 @@
 
 namespace tool_objectfs;
 
+use coding_exception;
 use tool_objectfs\local\store\object_file_system;
 use tool_objectfs\local\manager;
+use tool_objectfs\local\tag\tag_manager;
+use tool_objectfs\tests\test_client;
 use tool_objectfs\tests\test_file_system;
 
 /**
@@ -1037,5 +1040,156 @@ class object_file_system_test extends tests\testcase {
         $this->assertEquals($contenthash, $result[0]);
         $this->assertEquals(\core_text::strlen($content), $result[1]);
         $this->assertTrue($result[2]);
+    }
+
+    /**
+     * Test syncing tags throws exception when client does not support tagging.
+     */
+    public function test_push_object_tags_not_supported() {
+        global $CFG;
+        $CFG->phpunit_objectfs_supports_object_tagging = false;
+
+        // Ensure we are using the test file system, and not the integration one (if in use).
+        if (!$this->filesystem->externalclient instanceof test_client) {
+            $this->markTestSkipped("Cannot test unsupported tagging while integration testing");
+            return;
+        }
+
+        $this->expectException(coding_exception::class);
+        $this->expectExceptionMessage('Cannot sync tags, external client does not support tagging');
+        $this->filesystem->push_object_tags('1234');
+    }
+
+    /**
+     * Tests syncing object tags where the file is not replicated.
+     */
+    public function test_push_object_tags_object_not_replicated() {
+        global $CFG, $DB;
+        $CFG->phpunit_objectfs_supports_object_tagging = true;
+
+        // Create object - not replicated to 'external' store yet.
+        $object = $this->create_local_object('test syncing local');
+
+        // Sync, this should do nothing but change sync status - cannot sync object tags
+        // where the object is not replicated.
+        $this->filesystem->push_object_tags($object->contenthash);
+        $object = $DB->get_record('tool_objectfs_objects', ['contenthash' => $object->contenthash]);
+        $this->assertEquals($object->tagsyncstatus, tag_manager::SYNC_STATUS_COMPLETE);
+    }
+
+    /**
+     * Provides values to push_object_tags_replicated
+     * @return array
+     */
+    public static function push_object_tags_replicated_provider(): array {
+        return [
+            // Can override, doesn't matter if envs are different.
+            'can override - different env' => [
+                'object env' => 'prod',
+                'push env' => 'staging',
+                'can override' => true,
+                'expected override' => true,
+            ],
+            'can override - same env' => [
+                'object env' => 'prod',
+                'push env' => 'prod',
+                'can override' => true,
+                'expected override' => true,
+            ],
+            'can override - empty env' => [
+                'object env' => '',
+                'push env' => 'prod',
+                'can override' => true,
+                'expected override' => true,
+            ],
+            // Cannot override, env must match or be empty.
+            'cannot override - same env' => [
+                'object env' => 'prod',
+                'push env' => 'prod',
+                'can override' => false,
+                'expected override' => true,
+            ],
+            'cannot override - different env' => [
+                'object env' => 'prod',
+                'push env' => 'staging',
+                'can override' => false,
+                'expected override' => false,
+            ],
+            'cannot override - env is empty' => [
+                'object env' => '',
+                'push env' => 'staging',
+                'can override' => false,
+                'expected override' => true,
+            ],
+        ];
+    }
+
+    /**
+     * Tests push_object_tags when the object is replicated.
+     * Tests rules around overriding are correctly applied.
+     *
+     * @param string $objectenv the env to set when 'uploading' the object
+     * @param string $pushenv the env to set when trying to push new tags
+     * @param bool $canoverride if filesystem should be able to overwrite existing objects
+     * @param bool $expectedoverride if it was expected that the tags were overwritten.
+     * @dataProvider push_object_tags_replicated_provider
+     */
+    public function test_push_object_tags_replicated(string $objectenv, string $pushenv, bool $canoverride,
+        bool $expectedoverride) {
+        global $CFG, $DB;
+        $CFG->phpunit_objectfs_supports_object_tagging = true;
+        set_config('taggingenvironment', $objectenv, 'tool_objectfs');
+
+        set_config('overwriteobjecttags', $canoverride, 'tool_objectfs');
+        $this->assertEquals($canoverride, tag_manager::can_overwrite_object_tags());
+
+        $object = $this->create_duplicated_object('test syncing replicated');
+        $testtags = tag_manager::gather_object_tags_for_upload($object->contenthash);
+
+        // Fake set the tags in the external store.
+        $this->filesystem->get_external_client()->set_object_tags($object->contenthash, $testtags);
+
+        // Ensure tags are set 'externally'.
+        $tags = $this->filesystem->get_external_client()->get_object_tags($object->contenthash);
+        $this->assertCount(count($testtags), $tags);
+
+        // But tags will not be stored locally (yet).
+        $localtags = $DB->get_records('tool_objectfs_object_tags', ['objectid' => $object->id]);
+        $this->assertCount(0, $localtags);
+
+        set_config('taggingenvironment', $pushenv, 'tool_objectfs');
+
+        // Sync the file.
+        $this->filesystem->push_object_tags($object->contenthash);
+
+        // Tags should now be replicated locally.
+        $localtags = $DB->get_records('tool_objectfs_object_tags', ['objectid' => $object->id]);
+        $externaltags = $this->filesystem->get_external_client()->get_object_tags($object->contenthash);
+        $time = $DB->get_field('tool_objectfs_objects', 'tagslastpushed', ['id' => $object->id]);
+
+        if ($expectedoverride) {
+            // If can override, we expect it to be overwritten by the tags defined in the sources.
+            $expectednum = count(tag_manager::get_defined_tag_sources());
+            $this->assertCount($expectednum, $localtags);
+
+            // Also expect the external store to be updated.
+            $this->assertCount($expectednum, $externaltags);
+
+            // Tag push time should be set, since it actually pushed the tags.
+            $this->assertNotEquals(0, $time);
+        } else {
+            // If cannot overwrite, no tags should be synced.
+            $this->assertCount(0, $localtags);
+
+            // External store should not be changed.
+            $this->assertCount(count($testtags), $externaltags);
+
+            // The tag last push time should remain unchanged, since it didn't actually push any tags.
+            $this->assertEquals(0, $time);
+        }
+
+        // Ensure status changed to not needing sync.
+        $object = $DB->get_record('tool_objectfs_objects', ['contenthash' => $object->contenthash]);
+        $this->assertEquals($object->tagsyncstatus, tag_manager::SYNC_STATUS_COMPLETE);
     }
 }

--- a/tests/task/populate_objects_filesize_test.php
+++ b/tests/task/populate_objects_filesize_test.php
@@ -28,13 +28,6 @@ namespace tool_objectfs\task;
 class populate_objects_filesize_test extends \tool_objectfs\tests\testcase {
 
     /**
-     * This method runs before every test.
-     */
-    public function setUp(): void {
-        $this->resetAfterTest();
-    }
-
-    /**
      * Test multiple objects have their filesize updated.
      */
     public function test_empty_filesizes_updated() {
@@ -214,6 +207,8 @@ class populate_objects_filesize_test extends \tool_objectfs\tests\testcase {
      */
     public function test_objects_with_error_are_not_updated() {
         global $DB;
+        $numstart = $DB->count_records('tool_objectfs_objects');
+
         $file1 = $this->create_local_file("Test 1");
         $this->create_local_file("Test 2");
         $this->create_local_file("Test 3");
@@ -237,7 +232,7 @@ class populate_objects_filesize_test extends \tool_objectfs\tests\testcase {
         });
 
         // Test that 4 records have now been updated.
-        $this->assertCount(5, $objects);
-        $this->assertCount(4, $updatedobjects);
+        $this->assertEquals(5, count($objects) - $numstart);
+        $this->assertEquals(4, count($updatedobjects) - $numstart);
     }
 }

--- a/tests/task/trigger_update_object_tags_test.php
+++ b/tests/task/trigger_update_object_tags_test.php
@@ -1,0 +1,50 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\task;
+
+use advanced_testcase;
+use core\task\manager;
+
+/**
+ * Tests trigger_update_object_tags
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class trigger_update_object_tags_test extends advanced_testcase {
+    /**
+     * Tests executing scheduled task.
+     * @covers \tool_objectfs\task\trigger_update_object_tags::execute
+     */
+    public function test_execute() {
+        $this->resetAfterTest();
+
+        $task = new trigger_update_object_tags();
+        $task->execute();
+
+        // Ensure it spawned an adhoc task.
+        $queuedadhoctasks = manager::get_adhoc_tasks(update_object_tags::class);
+        $this->assertCount(1, $queuedadhoctasks);
+
+        // Ensure the adhoc task spawned has an iteration of 1.
+        $adhoctask = current($queuedadhoctasks);
+        $this->assertNotEmpty($adhoctask->get_custom_data());
+        $this->assertEquals(1, $adhoctask->get_custom_data()->iteration);
+    }
+}

--- a/tests/task/update_object_tags_test.php
+++ b/tests/task/update_object_tags_test.php
@@ -1,0 +1,204 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\task;
+
+use core\task\manager;
+use moodle_exception;
+use tool_objectfs\local\tag\tag_manager;
+use tool_objectfs\tests\testcase;
+
+/**
+ * Tests update_object_tags
+ *
+ * @package   tool_objectfs
+ * @author    Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright Catalyst IT
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \tool_objectfs\task\update_object_tags
+ */
+class update_object_tags_test extends testcase {
+    /**
+     * Creates object with tags needing to be synced
+     * @param string $contents contents of object to create.
+     * @return stdClass object record
+     */
+    private function create_object_needing_tag_sync(string $contents) {
+        global $DB;
+        $object = $this->create_duplicated_object($contents);
+        $DB->set_field('tool_objectfs_objects', 'tagsyncstatus', tag_manager::SYNC_STATUS_NEEDS_SYNC, ['id' => $object->id]);
+        return $object;
+    }
+
+    /**
+     * Tests task exits when the tagging feature is disabled.
+     */
+    public function test_not_enabled() {
+        $this->resetAfterTest();
+
+        // By default filesystem does not support and tagging not enabled, so should error.
+        $task = new update_object_tags();
+
+        $this->expectException(moodle_exception::class);
+        $this->expectExceptionMessage(get_string('tagging:migration:notsupported', 'tool_objectfs'));
+        $task->execute();
+    }
+
+    /**
+     * Tests handles an invalid iteration limit
+     */
+    public function test_invalid_iteration_limit() {
+        $this->resetAfterTest();
+        $this->enable_filesystem_and_set_tagging(true);
+
+        // This should be greater than 1, if zero should error.
+        set_config('maxtaggingiterations', 0, 'tool_objectfs');
+
+        // Give it a valid iteration number though.
+        $task = new update_object_tags();
+        $task->set_custom_data(['iteration' => 5]);
+
+        $this->expectException(moodle_exception::class);
+        $this->expectExceptionMessage(get_string('tagging:migration:invaliditerations', 'tool_objectfs'));
+        $task->execute();
+    }
+
+    /**
+     * Tests handles an invalid number of iterations in custom data
+     */
+    public function test_invalid_iteration_number() {
+        $this->resetAfterTest();
+        $this->enable_filesystem_and_set_tagging(true);
+
+        // Give it a valid max iteration number.
+        set_config('maxtaggingiterations', 5, 'tool_objectfs');
+
+        // But don't set the iteration number on the customdata at all.
+        $this->expectException(moodle_exception::class);
+        $this->expectExceptionMessage(get_string('tagging:migration:invaliditerations', 'tool_objectfs'));
+
+        $task = new update_object_tags();
+        $task->execute();
+    }
+
+    /**
+     * Tests exits when there are no more objects needing to be synced
+     */
+    public function test_no_more_objects_to_sync() {
+        $this->resetAfterTest();
+        $this->enable_filesystem_and_set_tagging(true);
+        set_config('maxtaggingiterations', 5, 'tool_objectfs');
+        $task = new update_object_tags();
+        $task->set_custom_data(['iteration' => 1]);
+
+        // This should not error, only output a string since it is successfully completed.
+        $this->expectOutputString("No more objects found that need tagging, exiting.\n");
+        $task->execute();
+    }
+
+    /**
+     * Tests maxtaggingiterations is correctly checked
+     */
+    public function test_max_iterations() {
+        $this->resetAfterTest();
+        $this->enable_filesystem_and_set_tagging(true);
+
+        // Set max 1 iteration.
+        set_config('maxtaggingiterations', 1, 'tool_objectfs');
+        set_config('maxtaggingperrun', 100, 'tool_objectfs');
+
+        $task = new update_object_tags();
+
+        // Give it an iteration number higher.
+        $task->set_custom_data(['iteration' => 5]);
+
+        $this->expectException(moodle_exception::class);
+        $this->expectExceptionMessage(get_string('tagging:migration:limitreached', 'tool_objectfs', 5));
+        $task->execute();
+    }
+
+    /**
+     * Tests a successful tagging run where it needs to requeue for further processing
+     */
+    public function test_tagging_run_with_requeue() {
+        $this->resetAfterTest();
+        $this->enable_filesystem_and_set_tagging(true);
+
+        // Set max 1 object per run.
+        set_config('maxtaggingperrun', 1, 'tool_objectfs');
+        set_config('maxtaggingiterations', 5, 'tool_objectfs');
+
+        // Create two objects needing sync.
+        $this->create_object_needing_tag_sync('object 1');
+        $this->create_object_needing_tag_sync('object 2');
+        $this->assertCount(2, tag_manager::get_objects_needing_sync(100));
+
+        $task = new update_object_tags();
+        $task->set_custom_data(['iteration' => 1]);
+
+        $this->expectOutputString("Requeing self for another iteration.\n");
+        $task->execute();
+
+        // Ensure that 1 object had its sync status updated.
+        $this->assertCount(1, tag_manager::get_objects_needing_sync(100));
+
+        // Ensure there is another task that was re-queued with the iteration incremented.
+        $tasks = manager::get_adhoc_tasks(update_object_tags::class);
+        $this->assertCount(1, $tasks);
+        $task = current($tasks);
+        $this->assertNotEmpty($task->get_custom_data());
+        $this->assertEquals(2, $task->get_custom_data()->iteration);
+    }
+
+    /**
+     * Tests get_iteration
+     * @covers \tool_objectfs\task\update_object_tags::get_iteration
+     */
+    public function test_get_iteration() {
+        $task = new update_object_tags();
+
+        // No custom data, should return zero.
+        $this->assertEquals(0, $task->get_iteration());
+
+        // Set iteration, it should return that.
+        $task->set_custom_data([
+            'iteration' => 5,
+        ]);
+        $this->assertEquals(5, $task->get_iteration());
+    }
+
+    /**
+     * Tests getting status badge
+     * @covers \tool_objectfs\task\update_object_tags::get_status_badge
+     */
+    public function test_get_status_badge() {
+        // Spawn three tasks and break each one in a different way.
+        // Test their badge output.
+        $task1 = new update_object_tags();
+        $this->assertStringContainsString(get_string('status:waiting', 'tool_objectfs'),
+            $task1->get_status_badge());
+
+        $task2 = new update_object_tags();
+        $task2->set_fail_delay(1000);
+        $this->assertStringContainsString(get_string('status:failing', 'tool_objectfs', 1000),
+            $task2->get_status_badge());
+
+        $task3 = new update_object_tags();
+        $task3->set_timestarted(1000);
+        $this->assertStringContainsString(get_string('status:running', 'tool_objectfs'),
+            $task3->get_status_badge());
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024112000;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2024112000;      // Same as version.
+$plugin->version   = 2024120600;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2024120600;      // Same as version.
 $plugin->requires  = 2024042200;      // Requires 4.4.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Cherry pick of https://github.com/catalyst/moodle-tool_objectfs/pull/619 to `MOODLE_404_STABLE` branch
This code has already been reviewed & tested, this is purely a forward-port.

Did make some very small php version specific tweaks to fix some deprecations in the newer php version

**Testing**
- Tested manually including upgrade from previous version - successfully completes
- unit tests run with s3 integration client - successfully completes