### PR TITLE
deleter: check for any falsy value of deletelocal

### DIFF
--- a/classes/local/object_manipulator/deleter.php
+++ b/classes/local/object_manipulator/deleter.php
@@ -78,7 +78,7 @@ class deleter extends manipulator {
      * @return bool
      */
     protected function manipulator_can_execute() {
-        if ($this->deletelocal == 0) {
+        if (!$this->deletelocal) {
             mtrace("Delete local disabled \n");
             return false;
         }


### PR DESCRIPTION
Moodle stores the value `false` as an empty string in the database.
This results in undesired behaviour from `manipulator_can_execute()` since `'' == 0` evaluates to `true` in php7 but `false` in php8.