### PR TITLE
Objectfs mimetype null/string handling

### DIFF
--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -178,11 +178,12 @@ abstract class object_file_system extends \file_system_filedir {
 
         // We limit 1 because multiple files can have the same contenthash.
         // However, they all have the same mimetype so it does not matter which one we query.
-        return $DB->get_field_sql('SELECT mimetype
+        $mimetype = $DB->get_field_sql('SELECT mimetype
                               FROM {files}
                              WHERE contenthash = :hash
                              LIMIT 1',
                         ['hash' => $contenthash]);
+        return !empty($mimetype) ? $mimetype : '';
     }
 
     /**


### PR DESCRIPTION
Fix for Task Failure in \tool_objectfs\task\push_objects_to_storage

The task \tool_objectfs\task\push_objects_to_storage was failing with the error:
`Return value must be of type string, null returned.`

The root cause was identified as files with an empty mimetype in the database, which were returning null instead of a valid string.

This PR introduces a fix to ensure that when an empty mimetype is encountered, an empty string ('') is returned instead of null. This aligns with the expected return type (string) and prevents the task from failing.