### PR TITLE
Add a ACL option to set access permission in S3 bucket

### DIFF
--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -178,11 +178,12 @@ abstract class object_file_system extends \file_system_filedir {
 
         // We limit 1 because multiple files can have the same contenthash.
         // However, they all have the same mimetype so it does not matter which one we query.
-        return $DB->get_field_sql('SELECT mimetype
+        $mimetype = $DB->get_field_sql('SELECT mimetype
                               FROM {files}
                              WHERE contenthash = :hash
                              LIMIT 1',
                         ['hash' => $contenthash]);
+        return !empty($mimetype) ? $mimetype : '';
     }
 
     /**

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -29,7 +29,6 @@ use coding_exception;
 use tool_objectfs\local\manager;
 use tool_objectfs\local\store\object_client_base;
 use tool_objectfs\local\store\signed_url;
-use local_aws\admin_settings_aws_region;
 use stdClass;
 use Throwable;
 


### PR DESCRIPTION
This PR address the issue in https://github.com/catalyst/moodle-tool_objectfs/issues/614

Similar [PR](https://github.com/catalyst/moodle-tool_objectfs/pull/661) for for `MOODLE_404_STABLE` 