### PR TITLE
Fix Creation of property bucketacl deprecated #675

### DIFF
--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -65,6 +65,9 @@ class client extends object_client_base {
     /** @var string Prefix for bucket keys */
     protected $bucketkeyprefix;
 
+    /** @var string $bucketacl option to set access permission in S3 bucket */
+    private $bucketacl;
+
     /**
      * construct
      * @param mixed $config


### PR DESCRIPTION
Fix warning PHP Deprecated: Creation of dynamic property tool_objectfs\local\store\s3\client::$bucketacl is deprecated.

Proposed fix for #675.