### PR TITLE
Improve chart formatting #679

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,7 @@
 .ofs-bar {
-    background: #17a5eb;
     white-space: nowrap;
+}
+
+.ofs-bar-column {
+    min-width: 12vw;
 }

--- a/tests/local/report/object_status_test.php
+++ b/tests/local/report/object_status_test.php
@@ -169,24 +169,22 @@ class object_status_test extends \tool_objectfs\tests\testcase {
      * @return array
      */
     public static function object_status_add_barchart_method_provider(): array {
+        $html = '<div class="ofs-bar table-info" style="width:%s%%">%s</div>';
+        $runninghtml = '<div class="ofs-bar table-info" style="width:%s%%">%s%% (%s)</div>';
         return [
             [0, 0, '', 0, '0'],
-            [0, 100, 'count', 0, '<div class="ofs-bar" style="width:0%">' . number_format(0) . '</div>'],
-            [0, 100, 'size', 0, '<div class="ofs-bar" style="width:0%">' . display_size(0) . '</div>'],
-            [0, 100, 'runningsize', 0,
-                '<div class="ofs-bar" style="width:0%">' . number_format(0) . '% (' . display_size(0) . ')</div>'],
-            [0, 100, 'count', 2, '<div class="ofs-bar" style="width:0%">' . number_format(0) . '</div>'],
-            [0, 100, 'size', 2, '<div class="ofs-bar" style="width:0%">' . display_size(0) . '</div>'],
-            [0, 100, 'runningsize', 2,
-                '<div class="ofs-bar" style="width:0%">' . number_format(0, 2) . '% (' . display_size(0) . ')</div>'],
-            [10, 100, 'count', 2, '<div class="ofs-bar" style="width:10%">' . number_format(10) . '</div>'],
-            [10, 100, 'size', 2, '<div class="ofs-bar" style="width:10%">' . display_size(10) . '</div>'],
-            [10, 100, 'runningsize', 2,
-                '<div class="ofs-bar" style="width:10%">' . number_format(10, 2) . '% (' . display_size(10) . ')</div>'],
-            [12345678, 123456789, 'count', 0, '<div class="ofs-bar" style="width:10%">' . number_format(12345678) . '</div>'],
-            [12345678, 123456789, 'size', 0, '<div class="ofs-bar" style="width:10%">' . display_size(12345678) . '</div>'],
-            [12345678, 123456789, 'runningsize', 2,
-                '<div class="ofs-bar" style="width:10%">' . number_format(10, 2) . '% (' . display_size(12345678) . ')</div>'],
+            [0, 100, 'count', 0, sprintf($html, 0, number_format(0))],
+            [0, 100, 'size', 0, sprintf($html, 0, display_size(0))],
+            [0, 100, 'runningsize', 0, sprintf($runninghtml, 0, number_format(0), display_size(0))],
+            [0, 100, 'count', 2, sprintf($html, 0, number_format(0))],
+            [0, 100, 'size', 2, sprintf($html, 0, display_size(0))],
+            [0, 100, 'runningsize', 2, sprintf($runninghtml, 0, number_format(0, 2), display_size(0))],
+            [10, 100, 'count', 2, sprintf($html, 10, number_format(10))],
+            [10, 100, 'size', 2, sprintf($html, 10, display_size(10))],
+            [10, 100, 'runningsize', 2, sprintf($runninghtml, 10, number_format(10, 2), display_size(10))],
+            [12345678, 123456789, 'count', 0, sprintf($html, 10, number_format(12345678))],
+            [12345678, 123456789, 'size', 0, sprintf($html, 10, display_size(12345678))],
+            [12345678, 123456789, 'runningsize', 2, sprintf($runninghtml, 10, number_format(10, 2), display_size(12345678))],
         ];
     }
 
@@ -203,7 +201,7 @@ class object_status_test extends \tool_objectfs\tests\testcase {
      */
     public function test_object_status_add_barchart_method($value, $max, $type, $precision, $expected) {
         $table = new object_status_history_table('location', 0);
-        $actual = $table->add_barchart($value, $max, $type, $precision);
+        $actual = $table->add_barchart($value, '', $max, $type, $precision);
         $this->assertEquals($expected, $actual);
     }
 

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025031800;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2025031800;      // Same as version.
+$plugin->version   = 2025040900;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2025040900;      // Same as version.
 $plugin->requires  = 2024042200;      // Requires 4.4.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
- Formats location table based on success/warning/danger/info

I ended up using table-* to make them more readable, as bg-* was too harsh on black text and white text was not usable for parts outside the bar. The default was updated to table-info to match the others.

- Updates column width

Closes #679 