### PR TITLE
Optimize tag summary

### DIFF
--- a/classes/local/tag/tag_manager.php
+++ b/classes/local/tag/tag_manager.php
@@ -235,9 +235,21 @@ class tag_manager {
      */
     public static function get_tag_sync_status_summary(): array {
         global $DB;
-        return $DB->get_records_sql("SELECT tagsyncstatus, COUNT(tagsyncstatus) as statuscount
+        $cachekey = 'tag_sync_status_summary';
+        $cache = \cache::make('tool_objectfs', 'tagsummary');
+        $cachedresult = $cache->get($cachekey);
+
+        if ($cachedresult !== false) {
+            return $cachedresult;
+        }
+
+        $result = $DB->get_records_sql("SELECT tagsyncstatus, COUNT(tagsyncstatus) as statuscount
                                        FROM {tool_objectfs_objects}
                                    GROUP BY tagsyncstatus");
+
+        $cache->set($cachekey, $result);
+
+        return $result;
     }
 
     /**

--- a/db/caches.php
+++ b/db/caches.php
@@ -15,19 +15,20 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version information.
+ * Cache definitions for tool_objectfs
  *
  * @package   tool_objectfs
- * @author    Kenneth Hendricks <kennethhendricks@catalyst-au.net>
  * @copyright Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025082701;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2025082701;      // Same as version.
-$plugin->requires  = 2024042200;      // Requires 4.4.
-$plugin->component = "tool_objectfs";
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->supported = [404, 405];
+$definitions = [
+    'tagsummary' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'ttl' => 1800,
+        'simplekeys' => true,
+        'simpledata' => true,
+    ],
+];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -220,5 +220,15 @@ function xmldb_tool_objectfs_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2024120600, 'tool', 'objectfs');
     }
 
+    if ($oldversion < 2025082701) {
+        $table = new xmldb_table('tool_objectfs_objects');
+        $index = new xmldb_index('tagsyncstatus_idx', XMLDB_INDEX_NOTUNIQUE, ['tagsyncstatus']);
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        upgrade_plugin_savepoint(true, 2025082701, 'tool', 'objectfs');
+    }
+
     return true;
 }

--- a/tests/check/tagging_sync_status_test.php
+++ b/tests/check/tagging_sync_status_test.php
@@ -65,4 +65,31 @@ final class tagging_sync_status_test extends testcase {
         $check = new tagging_sync_status();
         $this->assertEquals(result::WARNING, $check->get_result()->get_status());
     }
+
+    /**
+     * Test caching
+     */
+    public function test_tag_sync_status_summary_caching() {
+        global $DB;
+        $this->enable_filesystem_and_set_tagging(true);
+
+        $cache = \cache::make('tool_objectfs', 'tagsummary');
+        $cache->delete('tag_sync_status_summary');
+
+        $this->assertEquals($cache->get('tag_sync_status_summary'), false);
+
+        // Test: First call should hit DB, second should use cache.
+        $before = $DB->perf_get_queries();
+        $result1 = tag_manager::get_tag_sync_status_summary();
+        $after1 = $DB->perf_get_queries();
+
+        $this->assertNotEquals($cache->get('tag_sync_status_summary'), false);
+
+        $result2 = tag_manager::get_tag_sync_status_summary();
+        $after2 = $DB->perf_get_queries();
+
+        $this->assertGreaterThan($before, $after1, 'First call should hit DB');
+        $this->assertEquals($after1, $after2, 'Second call should use cache');
+        $this->assertEquals($result1, $result2, 'Cached and DB results should match');
+    }
 }


### PR DESCRIPTION
Addresses issue #686 

Query

```
EXPLAIN (ANALYZE, BUFFERS) SELECT tagsyncstatus, COUNT(tagsyncstatus) as statuscount
FROM {tool_objectfs_objects}
GROUP BY tagsyncstatus
```

Before Index

```
QUERY PLAN
Limit (cost=9458.77..9509.44 rows=200 width=10) (actual time=25.231..27.320 rows=1 loops=1)
Buffers: shared hit=1166 read=4592
-> Finalize GroupAggregate (cost=9458.77..9509.44 rows=200 width=10) (actual time=25.230..27.319 rows=1 loops=1)
Group Key: tagsyncstatus
Buffers: shared hit=1166 read=4592
-> Gather Merge (cost=9458.77..9505.44 rows=400 width=10) (actual time=25.224..27.313 rows=3 loops=1)
Workers Planned: 2
Workers Launched: 2
Buffers: shared hit=1166 read=4592
-> Sort (cost=8458.74..8459.24 rows=200 width=10) (actual time=22.668..22.669 rows=1 loops=3)
Sort Key: tagsyncstatus
Sort Method: quicksort Memory: 25kB
Buffers: shared hit=1166 read=4592
Worker 0: Sort Method: quicksort Memory: 25kB
Worker 1: Sort Method: quicksort Memory: 25kB
-> Partial HashAggregate (cost=8449.10..8451.10 rows=200 width=10) (actual time=22.654..22.655 rows=1 loops=3)
Group Key: tagsyncstatus
Batches: 1 Memory Usage: 40kB
Buffers: shared hit=1152 read=4592
Worker 0: Batches: 1 Memory Usage: 40kB
Worker 1: Batches: 1 Memory Usage: 40kB
-> Parallel Seq Scan on mdl_tool_objectfs_objects (cost=0.00..7547.40 rows=180340 width=2) (actual time=0.018..11.493 rows=144272 loops=3)
Buffers: shared hit=1152 read=4592
Planning:
Buffers: shared hit=57
Planning Time: 0.120 ms
Execution Time: 27.342 ms
```

After Index

```
Limit (cost=1000.45..7469.80 rows=200 width=10) (actual time=15.054..16.905 rows=1 loops=1)
Buffers: shared hit=370
-> Finalize GroupAggregate (cost=1000.45..7469.80 rows=200 width=10) (actual time=15.053..16.904 rows=1 loops=1)
Group Key: tagsyncstatus
Buffers: shared hit=370
-> Gather Merge (cost=1000.45..7465.80 rows=400 width=10) (actual time=15.050..16.900 rows=3 loops=1)
Workers Planned: 2
Workers Launched: 2
Buffers: shared hit=370
-> Partial GroupAggregate (cost=0.42..6419.60 rows=200 width=10) (actual time=12.577..12.577 rows=1 loops=3)
Group Key: tagsyncstatus
Buffers: shared hit=370
-> Parallel Index Only Scan using mdl_toolobjeobje_tag_ix on mdl_tool_objectfs_objects (cost=0.42..5515.90 rows=180340 width=2) (actual time=0.023..6.061 rows=144272 loops=3)
Heap Fetches: 0
Buffers: shared hit=370
Planning:
Buffers: shared hit=71
Planning Time: 0.146 ms
Execution Time: 16.923 ms
```