### PR TITLE
fix(s3.client): catch AWS `UnresolvedAuthSchemeException` when testing connection on Moodle 5

### DIFF
--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -321,6 +321,9 @@ class client extends object_client_base {
             } else {
                 $this->client->headBucket(['Bucket' => $this->bucket]);
             }
+        } catch (\Aws\Auth\Exception\UnresolvedAuthSchemeException $e) {
+            $connection->success = false;
+            $connection->details = $this->get_exception_details($e);
         } catch (\Aws\S3\Exception\S3Exception $e) {
             $connection->success = false;
             $connection->details = $this->get_exception_details($e);


### PR DESCRIPTION
Reference: https://github.com/catalyst/moodle-tool_objectfs/issues/685