### PR TITLE
Resolve issue #685

### DIFF
--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -321,6 +321,9 @@ class client extends object_client_base {
             } else {
                 $this->client->headBucket(['Bucket' => $this->bucket]);
             }
+        } catch (\Aws\Auth\Exception\UnresolvedAuthSchemeException $e) {
+            $connection->success = false;
+            $connection->details = $this->get_exception_details($e);
         } catch (\Aws\S3\Exception\S3Exception $e) {
             $connection->success = false;
             $connection->details = $this->get_exception_details($e);


### PR DESCRIPTION
Resolve "Signature V4 requires AWS credentials for request signing" Exception at Moodle 5.0.