### PR TITLE
Handles Azure blob storage failure for large files

### DIFF
--- a/classes/azure_blob_storage_file_system.php
+++ b/classes/azure_blob_storage_file_system.php
@@ -30,4 +30,21 @@ use tool_objectfs\local\store\azure_blob_storage\file_system;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class azure_blob_storage_file_system extends file_system {
+    /**
+    * Output the content of the specified stored file.
+    *
+    * Note, this is different to get_content() as it uses the built-in php
+    * readfile function which is more efficient.
+    *
+    * @param stored_file $file The file to serve.
+    * @return void
+    */
+    public function readfile(\stored_file $file) {
+        $path = $this->get_remote_path_from_storedfile($file);
+        if (readfile($path) === false) {
+            throw new \file_exception('storedfilecannotreadfile', $file->get_filename());
+        }
+    }
 }
+
+


### PR DESCRIPTION
- The change updates the Azure Blob storage file system to use standard readfile() simplifying the code and aligning to latest PHP capabilities
- get_remote_path_from_storedfile() function calls is_file_readable_locally_by_storedfile() hence calling it again is not needed
- This allows site admin to control whether it should check for local or external first
- The readfile() function in PHP is memory-efficient for large files since 2016 and readfile_allow_large might not be needed