### PR TITLE
Ensure Object Lock is released in case of exceptions

### DIFF
--- a/classes/local/object_manipulator/manipulator.php
+++ b/classes/local/object_manipulator/manipulator.php
@@ -109,13 +109,16 @@ abstract class manipulator implements object_manipulator {
                 continue;
             }
 
-            $newlocation = $this->manipulate_object($objectrecord);
-            if (!empty($objectrecord->id)) {
-                manager::upsert_object($objectrecord, $newlocation);
-            } else {
-                manager::update_object_by_hash($objectrecord->contenthash, $newlocation);
+            try {
+                $newlocation = $this->manipulate_object($objectrecord);
+                if (!empty($objectrecord->id)) {
+                    manager::upsert_object($objectrecord, $newlocation);
+                } else {
+                    manager::update_object_by_hash($objectrecord->contenthash, $newlocation);
+                }
+            } finally {
+                $objectlock->release();
             }
-            $objectlock->release();
         }
 
         $this->logger->end_timing();


### PR DESCRIPTION
Refactor object manipulation to ensure object lock is released after processing, even in case of exceptions.

Resolves issue #698 