### PR TITLE
Issue #718: Modified logic such that we can find objectfs settings via admin search.

### DIFF
--- a/classes/local/store/azure/client.php
+++ b/classes/local/store/azure/client.php
@@ -25,6 +25,8 @@
 
 namespace tool_objectfs\local\store\azure;
 
+use admin_setting;
+use admin_settingpage;
 use SimpleXMLElement;
 use stdClass;
 use tool_objectfs\local\store\azure\stream_wrapper;
@@ -339,7 +341,7 @@ class client extends object_client_base {
      * Shared Access Signature.
      *
      * @param admin_settingpage $settings
-     * @param  \stdClass $config
+     * @param object $config
      * @return admin_settingpage
      */
     public function define_client_section($settings, $config) {

--- a/classes/local/store/azure_blob_storage/client.php
+++ b/classes/local/store/azure_blob_storage/client.php
@@ -273,10 +273,10 @@ class client extends object_client_base {
      * Shared Access Signature.
      *
      * @param admin_settingpage $settings
-     * @param  \stdClass $config
+     * @param object $config
      * @return admin_settingpage
      */
-    public function define_client_section($settings, $config): admin_settingpage {
+    public function define_client_section($settings, $config) {
         $settings->add(new \admin_setting_heading(
             'tool_objectfs/azure',
             new \lang_string('settings:azure:header', 'tool_objectfs'),

--- a/classes/local/store/digitalocean/client.php
+++ b/classes/local/store/digitalocean/client.php
@@ -25,6 +25,7 @@
 
 namespace tool_objectfs\local\store\digitalocean;
 
+use admin_settingpage;
 use tool_objectfs\local\store\s3\client as s3_client;
 
 /**
@@ -91,7 +92,7 @@ class client extends s3_client {
     /**
      * define_client_section
      * @param admin_settingpage $settings
-     * @param \stdClass $config
+     * @param object $config
      * @return admin_settingpage
      */
     public function define_client_section($settings, $config) {

--- a/classes/local/store/object_client_base.php
+++ b/classes/local/store/object_client_base.php
@@ -112,6 +112,16 @@ abstract class object_client_base implements object_client {
     }
 
     /**
+     * Defines the setting section for the client. Logic is implemented by child classes.
+     *
+     * @param admin_settingpage $settings
+     * @param object $config
+     * @return admin_settingpage
+     */
+    abstract public function define_client_section($settings, $config);
+
+
+    /**
      * Moodle admin settings form to display connection details for the client service.
      *
      * @return string

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -25,6 +25,7 @@
 
 namespace tool_objectfs\local\store\s3;
 
+use admin_setting;
 use coding_exception;
 use tool_objectfs\local\manager;
 use tool_objectfs\local\store\object_client_base;

--- a/classes/local/store/swift/client.php
+++ b/classes/local/store/swift/client.php
@@ -344,7 +344,7 @@ class client extends object_client_base {
      * swift settings form with the following elements:
      *
      * @param \admin_settingpage $settings
-     * @param \stdClass $config
+     * @param object $config
      * @return \admin_settingpage
      */
     public function define_client_section($settings, $config) {

--- a/classes/tests/test_client.php
+++ b/classes/tests/test_client.php
@@ -142,6 +142,18 @@ class test_client extends object_client_base {
     }
 
     /**
+     * define_client_section
+     * @param mixed $settings
+     * @param mixed $config
+     *
+     * @return mixed
+     */
+    public function define_client_section($settings, $config) {
+        // No settings required for the test client.
+        return $settings;
+    }
+
+    /**
      * test_connection
      * @return \stdClass
      */

--- a/settings.php
+++ b/settings.php
@@ -214,7 +214,7 @@ if ($ADMIN->fulltree) {
     ));
 
     $client = \tool_objectfs\local\manager::get_client($config);
-    if ($client && $client->get_availability() && $objectfspage) {
+    if ($client && $client->get_availability()) {
         $settings = $client->define_client_section($settings, $config);
     }
 


### PR DESCRIPTION
#718

## Summary

Fixed issue where specific client settings would not show up when searching for them in admin search.

**Before**
<img width="352" height="123" alt="image" src="https://github.com/user-attachments/assets/9cf23a7d-bb10-4a69-8348-86c6bee1bde1" />

**After**
<img width="904" height="443" alt="image" src="https://github.com/user-attachments/assets/234bc316-f187-468a-bba7-6c2c65957bb6" />


**NOTE**
Sorry the issue number in the branch is incorrect, it should be 718. Mistyped.