### PR TITLE
Don't contact external server during file deletion unless needed

### DIFF
--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -718,7 +718,11 @@ abstract class object_file_system extends \file_system_filedir {
             // Don't remove the file - it's still in use.
             return;
         }
-        $this->delete_object_from_hash($contenthash);
+        if ($this->deleteexternally == TOOL_OBJECTFS_DELETE_EXTERNAL_FULL) {
+            $this->delete_object_from_hash($contenthash);
+        } else if ($this->is_file_readable_locally_by_hash($contenthash)) {
+            $this->delete_local_file_from_hash($contenthash);
+        }
     }
 
     /**


### PR DESCRIPTION
When you call `remove_file()`, this in turn calls `delete_object_from_hash()`, which then calls `get_object_location_from_hash()`, which in turn makes an HTTP request to the remote file store to see if the file is present there.

It uses this call to see if the file is present in the remote filestore, and if so, it calls `delete_external_file_from_hash()`. (It also checks to see if the file is present locally, and if so it calls `delete_local_file_from_hash()`).

But then, `delete_external_file_from_hash()` checks to see if the "Delete external file" setting is set to immediately delete external files. If it's not set for immediate deletion, the function does nothing, which means that HTTP request to get info about the file was not needed.

This patch adds logic to `remove_file()` so that it does an earlier check of that "Delete external file" setting, and if it's not set for immediate deletion, it skips the remote location lookup and just tries to delete the local file.

Skipping that one unnecessary remote file lookup helps immensely in cases where you're deleting a lot of files in a row, like `course/reset.php`

Changing this should not interfere with the orphaned file cleanup, because that calls `delete_external_file_from_hash()` directly, bypassing `remove_file()`.