### PR TITLE
Refactor reconciliation summary output and include skipped count on s…

### DIFF
--- a/classes/task/reconcile_filedir.php
+++ b/classes/task/reconcile_filedir.php
@@ -180,10 +180,7 @@ class reconcile_filedir extends task {
                         set_config('reconcile_file_lasthash', $lasthash, 'tool_objectfs');
                         mtrace("ObjectFS: Time limit reached.");
                         mtrace("ObjectFS: Finishing on hash {$lasthash}");
-                        mtrace(
-                            "ObjectFS: Processed {$processed}, deleted {$deleted}, " .
-                            "inserted {$inserted}, updated {$updated}, skipped {$skipped}."
-                        );
+                        $this->log_summary($processed, $deleted, $inserted, $updated, $skipped);
                         return;
                     }
 
@@ -282,10 +279,7 @@ class reconcile_filedir extends task {
                             \core\task\manager::static_caches_cleared_since($cronstart)
                         ) {
                             mtrace("ObjectFS: Graceful shutdown requested.");
-                            mtrace(
-                                "ObjectFS: Processed {$processed}, deleted {$deleted}, " .
-                                "inserted {$inserted}, updated {$updated}."
-                            );
+                            $this->log_summary($processed, $deleted, $inserted, $updated, $skipped);
                             return;
                         }
                     }
@@ -306,6 +300,29 @@ class reconcile_filedir extends task {
         if ($lasthash) {
             mtrace("ObjectFS: Finished on hash {$lasthash}");
         }
+        $this->log_summary($processed, $deleted, $inserted, $updated, $skipped);
+    }
+
+    /**
+     * Outputs a reconciliation summary to CLI.
+     *
+     * Logs the total number of processed, deleted, inserted, updated,
+     * and skipped files for the current execution cycle.
+     *
+     * @param int $processed Total number of files processed.
+     * @param int $deleted   Total number of files deleted.
+     * @param int $inserted  Total number of ObjectFS records inserted.
+     * @param int $updated   Total number of ObjectFS records updated.
+     * @param int $skipped   Total number of files skipped.
+     * @return void
+     */
+    private function log_summary(
+        int $processed,
+        int $deleted,
+        int $inserted,
+        int $updated,
+        int $skipped
+    ): void {
         mtrace(
             "ObjectFS: Processed {$processed}, deleted {$deleted}, " .
             "inserted {$inserted}, updated {$updated}, skipped {$skipped}."


### PR DESCRIPTION
This PR refactors the reconciliation summary output and includes a skipped count in the graceful shutdown output.

1. Introduce private log_summary() helper function.

2. Replace duplicated summary mtrace() calls with the helper.

3. The helper adds a skipped count to the graceful shutdown summary that is currently missing.

This ensures consistent summary output across all exit paths (completion, timeout, graceful shutdown) and reduces duplication.