### PR TITLE
Fix heartbeat check failure when ObjectFS is unconfigured

### DIFF
--- a/classes/check/connection.php
+++ b/classes/check/connection.php
@@ -48,7 +48,7 @@ class connection extends check {
         $config = manager::get_objectfs_config();
         $client = manager::get_client($config);
 
-        if (!$client->is_configured($config)) {
+        if (!$client || !$client->is_configured($config)) {
             return new result(result::NA, get_string('check:connection:na', 'tool_objectfs'));
         }
 


### PR DESCRIPTION
Fix regression introduced by 420903b2 which cause unit tests in **tool_heartbeat** to fail:

```
  There was 1 error:

  1) tool_heartbeat\checker_test::test_get_check_messages
  Error: Call to a member function is_configured() on bool

admin/tool/objectfs/classes/check/connection.php:51
admin/tool/heartbeat/classes/checker.php:419
admin/tool/heartbeat/classes/checker.php:174
admin/tool/heartbeat/classes/checker.php:94
admin/tool/heartbeat/tests/checker_test.php:40
lib/phpunit/classes/advanced_testcase.php:76
```