### PR TITLE
Store swift token in the Moodle Universal Cache

### DIFF
--- a/classes/check/connection.php
+++ b/classes/check/connection.php
@@ -48,7 +48,6 @@ class connection extends check {
         $config = manager::get_objectfs_config();
         $client = manager::get_client($config);
 
-
         if (empty($client) || !$client->is_configured($config)) {
             return new result(result::NA, get_string('check:connection:na', 'tool_objectfs'));
         }

--- a/classes/local/store/swift/client.php
+++ b/classes/local/store/swift/client.php
@@ -72,10 +72,14 @@ class client extends object_client_base {
             'scope'   => ['project' => ['id' => $this->config->openstack_projectid]],
         ];
 
+        // Try to get token from cache first.
+        $cache = \cache::make('tool_objectfs', 'openstack_authtoken');
+        $cachedtoken = $cache->get('openstack_authtoken');
+
         if (
-            !isset($this->config->openstack_authtoken['expires_at'])
+            !isset($cachedtoken['expires_at'])
             || (
-                new \DateTimeImmutable($this->config->openstack_authtoken['expires_at']))
+                new \DateTimeImmutable($cachedtoken['expires_at']))
                 <
                 ( (new \DateTimeImmutable('now'))->add(new \DateInterval('PT1H'))
             )
@@ -86,8 +90,10 @@ class client extends object_client_base {
             if ($lock = $lockfactory->get_lock('authtoken', 1)) {
                 try {
                     $openstack = new \OpenStack\OpenStack($endpoint);
-                    $this->config->openstack_authtoken = $openstack->identityV3()->generateToken($endpoint)->export();
-                    manager::set_objectfs_config(['openstack_authtoken' => serialize($this->config->openstack_authtoken)]);
+                    $newtoken = $openstack->identityV3()->generateToken($endpoint)->export();
+                    // Store token in cache.
+                    $cache->set('openstack_authtoken', $newtoken);
+                    $cachedtoken = $newtoken;
                     $lock->release();
                 } catch (\Exception $e) {
                     $lock->release();
@@ -97,13 +103,13 @@ class client extends object_client_base {
 
         // Use the token if it's valid, otherwise clients will need to use username/password auth.
         if (
-            isset($this->config->openstack_authtoken['expires_at'])
+            isset($cachedtoken['expires_at'])
             &&
-            new \DateTimeImmutable($this->config->openstack_authtoken['expires_at'])
+            new \DateTimeImmutable($cachedtoken['expires_at'])
             >
             new \DateTimeImmutable('now')
         ) {
-            $endpoint['cachedToken'] = $this->config->openstack_authtoken;
+            $endpoint['cachedToken'] = $cachedtoken;
         }
 
         return $endpoint;
@@ -193,8 +199,9 @@ class client extends object_client_base {
      * @return resource
      */
     public function get_seekable_stream_context() {
+        // Ensure valid token or refresh it.
+        $endpoint = $this->get_endpoint();
 
-        $this->get_endpoint();
         $context = stream_context_create([
             "swift" => [
                 'username' => $this->config->openstack_username,
@@ -203,7 +210,7 @@ class client extends object_client_base {
                 'tenantname' => $this->config->openstack_tenantname,
                 'endpoint' => $this->config->openstack_authurl,
                 'region' => $this->config->openstack_region,
-                'cachedtoken' => $this->config->openstack_authtoken,
+                'cachedtoken' => $endpoint['cachedToken'],
             ],
         ]);
         return $context;

--- a/db/caches.php
+++ b/db/caches.php
@@ -15,19 +15,23 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version information.
+ * Cache definitions for tool_objectfs.
  *
  * @package   tool_objectfs
- * @author    Kenneth Hendricks <kennethhendricks@catalyst-au.net>
+ * @author    Francis Devine <francis@catalyst.net.nz>
  * @copyright Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026030200;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2026022401;      // Same as version.
-$plugin->requires  = 2024042200;      // Requires 4.4.
-$plugin->component = "tool_objectfs";
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->supported = [404, 405];
+$definitions = [
+    'openstack_authtoken' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => true,
+        'simpledata' => true,
+        'ttl' => 3600, // 1 hour
+        // No reason to not let each node aquire it's own token.
+        'canuselocalstore' => true,
+    ],
+];


### PR DESCRIPTION
Presently tool_objectfs authenticates to openstack, then caches the resulting authtoken in the database (mdl_config_plugins / tool_objectfs / openstack_authtoken) until it expires.

This is undesirable from two angles:
1. When particulars change (eg destination project/tenant) in config.php the plugin continues using the existing token/details, acting on the wrong location (eg uploading files to the wrong location)

2. This cached token is available in database dumps, and when restored to non-prod environments, continuing to persist even if all MUC caches are purged on all web/cron servers.

This change moves the token to the Moodle Universal Cache, with a localstoreallowed definition, this means a purge of caches will remove the token.

I chose local store allowed as there's no reason to not allow each cluster server to acquire it's own token to openstack as you can have more than one token and the load from requesting tokens per node in the cluster is unlikely to be onerous (and you can store it in your fastest available cache)