### PR TITLE
Add's large object support in swift

### DIFF
--- a/classes/local/store/swift/client.php
+++ b/classes/local/store/swift/client.php
@@ -211,6 +211,7 @@ class client extends object_client_base {
                 'endpoint' => $this->config->openstack_authurl,
                 'region' => $this->config->openstack_region,
                 'cachedtoken' => $endpoint['cachedToken'],
+                'seekable' => true,
             ],
         ]);
         return $context;

--- a/classes/local/store/swift/client.php
+++ b/classes/local/store/swift/client.php
@@ -55,6 +55,20 @@ class client extends object_client_base {
         }
     }
 
+    public function get_availability() {
+        $result = parent::get_availability();
+        // local_openstack exists, check dependency is high enough version for
+        // large file support.
+        if ($result) {
+            $requirements = [
+                'local_openstack' => 2026040100,
+            ];
+            $pluginmanager = \core\plugin_manager::instance();
+            return $pluginmanager->are_dependencies_satisfied($requirements);
+        }
+        return $result;
+    }
+
     /**
      * get_endpoint
      * @return array

--- a/classes/local/store/swift/client.php
+++ b/classes/local/store/swift/client.php
@@ -46,7 +46,7 @@ class client extends object_client_base {
 
         if ($this->get_availability() && !empty($config)) {
             require_once($this->autoloader);
-            $this->maxupload = 5368709120; // 5GiB.
+            $this->maxupload = OBJECTFS_BYTES_IN_TERABYTE * 5;
             $this->containername = $config->openstack_container;
             $config->openstack_authtoken = unserialize($config->openstack_authtoken);
             $this->config = $config;

--- a/classes/local/store/swift/stream_wrapper.php
+++ b/classes/local/store/swift/stream_wrapper.php
@@ -28,6 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->dirroot . '/local/openstack/vendor/autoload.php');
 
 use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\CachingStream;
 
 /**
  * Stream wrapper for swift.
@@ -167,6 +168,36 @@ class stream_wrapper {
      */
     private static $defaultcontext;
 
+    /**  Name of the protocol e.g. swift
+     * @var string  
+     *
+     */
+    private $protocol = 'swift';
+
+    /**
+     * Tracks if a seek has been requested before the first read.
+     * When true, the next read will use an HTTP Range request instead of
+     * reading from the already-open sequential stream.
+     *
+     * @var bool
+     */
+    private $pendingseek = false;
+
+    /**
+     * The byte offset to seek to, used when $pendingseek is true.
+     *
+     * @var int
+     */
+    private $pendingseekoffset = 0;
+
+    /**
+     * Has the object stream has been fetched from Swift yet.
+     * We defer the download until the first read so that a seek
+     * preceding the read can be satisfied with a Range request.
+     *
+     * @var bool
+     */
+    private $streamfetched = false;
 
     // Stream API functions.
 
@@ -241,6 +272,9 @@ class stream_wrapper {
      * @return bool
      */
     public function stream_eof() {
+        if (!$this->streamfetched) {
+            return false;
+        }
         return $this->objstream->eof();
     }
 
@@ -282,9 +316,11 @@ class stream_wrapper {
         try {
             $this->object->retrieve();
 
-            if (empty($this->object->lastModified)) { // File exits even though retrieve worked.
-
+            if (empty($this->object->lastModified)) {
+                // File exists even though retrieve worked – treat as empty.
                 $this->objstream = new Stream(fopen('php://temp', $mode));
+                $this->streamfetched = true;
+
             } else {
                 if ($this->iswriting && $this->nooverwrite) {
                     trigger_error('File exists and cannot be overwritten', E_USER_WARNING);
@@ -292,14 +328,16 @@ class stream_wrapper {
                 }
 
                 if ($this->isappending || $this->isreading) {
-
-                    $this->objstream = $this->object->download();
-
+                    // Defer the download; it will be fetched lazily in
+                    // stream_read() once we know whether a Range is needed.
+                    $this->streamfetched = false;
+                    $this->objstream = null;
                 } else {
                     $this->objstream = new Stream(fopen('php://temp', $mode));
+                    $this->streamfetched = true;
                 }
 
-                if ($this->isappending) {
+                if ($this->isappending && $this->streamfetched) {
                     $this->objstream->seek(0, SEEK_END);
                 }
             }
@@ -312,30 +350,37 @@ class stream_wrapper {
             }
 
             $this->objstream = new Stream(fopen('php://temp', $mode));
+            $this->streamfetched = true;
 
         } catch (\Exception $e) {
             trigger_error('Failed to fetch object: ' . $e->getMessage(), E_USER_WARNING);
-
             return false;
         }
 
         return true;
     }
 
-
     /**
-     * Read from open stream
+     * Read from open stream.
      *
      * @param integer $count
      * @return string
      */
     public function stream_read($count) {
 
+        if (!$this->streamfetched) {
+            $this->fetch_stream_from_swift();
+        }
+
         return $this->objstream->read($count);
     }
 
     /**
-     * Set position of file pointer
+     * Perfom a seek request.
+     *
+     * If the underlying stream has not been fetched from Swift yet we simply use a
+     * a HTTP Range header.  If the stream is already open we seek
+     * within the local buffer as before.
      *
      * @param integer $offset
      * @param integer $whence
@@ -343,10 +388,21 @@ class stream_wrapper {
      */
     public function stream_seek($offset, $whence = SEEK_SET) {
 
+        if (!$this->streamfetched) {
+            if ($whence === SEEK_SET) {
+                $this->pendingseek = true;
+                $this->pendingseekoffset = $offset;
+                return true;
+            }
+
+            // For SEEK_CUR or SEEK_END we must download the full object first
+            // so we have something to seek within.
+            $this->fetch_stream_from_swift();
+        }
+
         $this->objstream->seek($offset, $whence);
         return true;
     }
-
 
     /**
      * Stat open file
@@ -367,6 +423,12 @@ class stream_wrapper {
      * @return integer
      */
     public function stream_tell() {
+
+        if (!$this->streamfetched) {
+            // Nothing has been downloaded yet; the logical position is
+            // whatever offset was recorded by the last stream_seek call.
+            return $this->pendingseek ? $this->pendingseekoffset : 0;
+        }
 
         return $this->objstream->tell();
     }
@@ -509,6 +571,47 @@ class stream_wrapper {
     //
     // Internal functions.
     //
+
+
+    /**
+     * Fetch the object stream from Swift, using an HTTP Range header if a
+     * seek was recorded before the first read.
+     *
+     * Sequential reads (no prior seek) download the object from byte 0 with
+     * no Range header, exactly as the original code did.
+     *
+     * Seeked reads request only "bytes=<offset>-"
+     *
+     * @return void
+     */
+    private function fetch_stream_from_swift() {
+
+        if ($this->streamfetched) {
+            return;
+        }
+
+        if ($this->pendingseek && $this->pendingseekoffset > 0) {
+            // Use an HTTP Range header to skip the leading bytes on the server.
+            $this->objstream = $this->object->download([
+                'requestOptions' => [
+                    'stream' => true,
+                    'headers' => [
+                        'Range' => 'bytes=' . $this->pendingseekoffset . '-',
+                    ]
+                ],
+            ]);
+        } else {
+            // Sequential read – no Range header, stream from the beginning.
+            $this->objstream = $this->object->download(['requestOptions' => ['stream' => true]]);
+
+            if ($this->isappending) {
+                $this->objstream->seek(0, SEEK_END);
+            }
+        }
+
+        $this->streamfetched = true;
+        $this->pendingseek = false;
+    }
 
     /**
      * Parse URL to object
@@ -727,6 +830,42 @@ class stream_wrapper {
         $final = array_values($values) + $values;
 
         return $final;
+    }
+
+     /**
+     * Get the stream context options available to the current stream
+     * @return array
+     */
+    private function get_options(): array {
+        // Context is not set when doing things like stat.
+        if ($this->context === null) {
+            $options = [];
+        } else {
+            $options = stream_context_get_options($this->context);
+            $options = isset($options[$this->protocol])
+                ? $options[$this->protocol]
+                : [];
+        }
+
+        $default = stream_context_get_options(stream_context_get_default());
+        $default = isset($default[$this->protocol])
+            ? $default[$this->protocol]
+            : [];
+        $result = $options + $default;
+
+        return $result;
+    }
+
+    /**
+     * Get a specific stream context option
+     *
+     * @param string $name Name of the option to retrieve
+     *
+     * @return mixed|null
+     */
+    private function get_option($name) {
+        $options = $this->get_options();
+        return isset($options[$name]) ? $options[$name] : null;
     }
 
 }

--- a/classes/local/store/swift/stream_wrapper.php
+++ b/classes/local/store/swift/stream_wrapper.php
@@ -585,11 +585,18 @@ class stream_wrapper {
         }
 
         try {
-            $this->object = $this->container->createObject([
-                'name' => $this->objectname,
-                'stream' => $this->objstream,
-            ]);
-
+            if ($this->objstream->getSize() > 5368709120) {
+                 $this->object = $this->container->createLargeObject([
+                    'name' => $this->objectname,
+                    'stream' => $this->objstream,
+                    'segmentContainer' => $this->container->name.'+segments',
+                ]);
+            } else {
+                $this->object = $this->container->createObject([
+                    'name' => $this->objectname,
+                    'stream' => $this->objstream,
+                ]);
+            }
             return true;
         } catch (\Exception $e) {
             trigger_error("Object creation failed", E_USER_WARNING);

--- a/classes/swift_file_system.php
+++ b/classes/swift_file_system.php
@@ -31,4 +31,22 @@ use tool_objectfs\local\store\swift\file_system;
  * [Description swift_file_system]
  */
 class swift_file_system extends file_system {
+
+    /**
+    * Output the content of the specified stored file.
+    *
+    * Note, this is different to get_content() as it uses the built-in php
+    * readfile function which is more efficient.
+    *
+    * @param stored_file $file The file to serve.
+    * @return void
+     */
+    public function readfile(\stored_file $file) {
+        \core_php_time_limit::raise(HOURSECS);
+        $path = $this->get_remote_path_from_storedfile($file);
+        if (readfile($path) === false) {
+            throw new \file_exception('storedfilecannotreadfile', $file->get_filename());
+        }
+    }
+ 
 }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026040800;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2026040800;      // Same as version.
+$plugin->version   = 2026041000;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2026041000;      // Same as version.
 $plugin->requires  = 2024042200;      // Requires 4.4.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
This adds large object support to the swift filesystem.

Downloads are now streamed, resulting in downloads starting without waiting for buffering.
    
Range requests are now passed to swift, this improves seeking in video content significantly.

This requires the user use an updated local_openstack version with a more modern SDK, so the availability function check now validates that the openstack dependency has the correct version.