### PR TITLE
742 remove external check

### DIFF
--- a/classes/local/store/object_file_system.php
+++ b/classes/local/store/object_file_system.php
@@ -523,7 +523,7 @@ abstract class object_file_system extends \file_system_filedir {
         if (
             $this->presigned_url_configured() &&
             $this->presigned_url_should_redirect_file($file) &&
-            $this->is_file_readable_externally_by_hash($contenthash)
+            $this->is_file_stored_externally_by_hash($contenthash)
         ) {
             return $this->redirect_to_presigned_url($contenthash, headers_list());
         }
@@ -531,7 +531,7 @@ abstract class object_file_system extends \file_system_filedir {
         $ranges = $this->get_valid_http_ranges($file->get_filesize());
         if (
             $this->externalclient->support_presigned_urls() && !empty($ranges) &&
-            $this->is_file_readable_externally_by_hash($contenthash)
+            $this->is_file_stored_externally_by_hash($contenthash)
         ) {
             return $this->externalclient->proxy_range_request($file, $ranges);
         }
@@ -557,7 +557,7 @@ abstract class object_file_system extends \file_system_filedir {
         $headers = headers_list();
         if (
             $this->presigned_url_configured() &&
-            $this->is_file_readable_externally_by_hash($contenthash) &&
+            $this->is_file_stored_externally_by_hash($contenthash) &&
             $this->presigned_url_should_redirect($contenthash, $headers)
         ) {
             return $this->redirect_to_presigned_url($contenthash, $headers);
@@ -1215,5 +1215,18 @@ abstract class object_file_system extends \file_system_filedir {
 
         // Else no match, do not set.
         return false;
+    }
+
+    /**
+     * According to the stored metadata, is this file stored externally?
+     *
+     * @param string $contenthash
+     * @return bool
+     */
+    private function is_file_stored_externally_by_hash(string $contenthash): bool {
+        global $DB;
+        $location = (int) $DB->get_field('tool_objectfs_objects', 'location', ['contenthash' => $contenthash]);
+
+        return $location === OBJECT_LOCATION_DUPLICATED || $location === OBJECT_LOCATION_EXTERNAL;
     }
 }

--- a/classes/local/store/swift/client.php
+++ b/classes/local/store/swift/client.php
@@ -55,9 +55,14 @@ class client extends object_client_base {
         }
     }
 
+    /**
+     * Returns true if the Client SDK exists and has been loaded.
+     *
+     * @return bool
+     */
     public function get_availability() {
         $result = parent::get_availability();
-        // local_openstack exists, check dependency is high enough version for
+        // If local_openstack exists, then check if dependency is a high enough version for
         // large file support.
         if ($result) {
             $requirements = [

--- a/classes/swift_file_system.php
+++ b/classes/swift_file_system.php
@@ -31,15 +31,14 @@ use tool_objectfs\local\store\swift\file_system;
  * [Description swift_file_system]
  */
 class swift_file_system extends file_system {
-
     /**
-    * Output the content of the specified stored file.
-    *
-    * Note, this is different to get_content() as it uses the built-in php
-    * readfile function which is more efficient.
-    *
-    * @param stored_file $file The file to serve.
-    * @return void
+     * Output the content of the specified stored file.
+     *
+     * Note, this is different to get_content() as it uses the built-in php
+     * readfile function which is more efficient.
+     *
+     * @param stored_file $file The file to serve.
+     * @return void
      */
     public function readfile(\stored_file $file) {
         \core_php_time_limit::raise(HOURSECS);
@@ -48,5 +47,4 @@ class swift_file_system extends file_system {
             throw new \file_exception('storedfilecannotreadfile', $file->get_filename());
         }
     }
- 
 }

--- a/classes/task/delete_orphaned_object_metadata.php
+++ b/classes/task/delete_orphaned_object_metadata.php
@@ -45,7 +45,7 @@ class delete_orphaned_object_metadata extends task {
     public function execute() {
         global $DB;
 
-        $ageforremoval = $this->config->maxorphanedage;
+        $ageforremoval = $this->config->maxorphanedage ?? null;
         if (empty($ageforremoval)) {
             mtrace('Skipping deletion of orphaned object metadata as maxorphanedage is set to an empty value.');
             return;

--- a/tests/object_file_system_test.php
+++ b/tests/object_file_system_test.php
@@ -1163,4 +1163,26 @@ final class object_file_system_test extends tests\testcase {
         $object = $DB->get_record('tool_objectfs_objects', ['contenthash' => $object->contenthash]);
         $this->assertEquals($object->tagsyncstatus, tag_manager::SYNC_STATUS_COMPLETE);
     }
+
+    /**
+     * Tests the is_file_stored_externally_by_hash function.
+     */
+    public function test_is_file_stored_externally_by_hash(): void {
+        $this->resetAfterTest();
+
+        $reflection = new \ReflectionMethod(object_file_system::class, 'is_file_stored_externally_by_hash');
+        $reflection->setAccessible(true);
+
+        // Create a remote file so that the contenthash will be marked as external.
+        $file = $this->create_remote_file();
+        $contenthash = $file->get_contenthash();
+        $result = $reflection->invokeArgs($this->filesystem, [$contenthash]);
+        $this->assertTrue($result);
+
+        // Create a local file so that the contenthash will be marked as local.
+        $file = $this->create_local_file('test_content_2');
+        $contenthash = $file->get_contenthash();
+        $result = $reflection->invokeArgs($this->filesystem, [$contenthash]);
+        $this->assertFalse($result);
+    }
 }

--- a/tests/task/task_reconcile_filedir_test.php
+++ b/tests/task/task_reconcile_filedir_test.php
@@ -65,8 +65,10 @@ final class task_reconcile_filedir_test extends testcase {
         );
 
         // Execute scheduled task.
+        ob_start();
         $task = new reconcile_filedir();
         $task->execute();
+        ob_end_clean();
 
         // Assertions.
 

--- a/tests/task/trigger_update_object_tags_test.php
+++ b/tests/task/trigger_update_object_tags_test.php
@@ -35,6 +35,9 @@ final class trigger_update_object_tags_test extends advanced_testcase {
     public function test_execute(): void {
         $this->resetAfterTest();
 
+        // Ensure this value is set to one, because the checks below assume it.
+        set_config('maxtaggingtaskstospawn', 1, 'tool_objectfs');
+
         $task = new trigger_update_object_tags();
         $task->execute();
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026041000;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2026041001;      // The current plugin version (Date: YYYYMMDDXX).
 $plugin->release   = 2026041000;      // Same as version.
 $plugin->requires  = 2024042200;      // Requires 4.4.
 $plugin->component = "tool_objectfs";

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2026041001;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2026041000;      // Same as version.
+$plugin->release   = 2026041001;      // Same as version.
 $plugin->requires  = 2024042200;      // Requires 4.4.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Resolves #742 

Create a new function is_file_stored_externally_by_hash() that checks the external availability purely by local metadata.

Replaces calls to is_file_readable_externally_by_hash() with this function in xsendfile() and xsendfile_file().

By doing this, it avoids making calls to the remote server, this improving performance.

Also, some unrelated CI fixes are made in a separate commit.
