### PR TITLE
Clean up settings page

### DIFF
--- a/classes/check/s3_sdkcreds.php
+++ b/classes/check/s3_sdkcreds.php
@@ -1,0 +1,63 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_objectfs\check;
+
+use core\check\check;
+use core\check\result;
+use tool_objectfs\local\manager;
+
+/**
+ * Status check for S3 SDK Credentials.
+ *
+ * @package    tool_objectfs
+ * @author     Benjamin Walker <benjaminwalker@catalyst-au.net>
+ * @copyright  Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class s3_sdkcreds extends check {
+    /**
+     * Link to ObjectFS settings page.
+     *
+     * @return \action_link|null
+     */
+    public function get_action_link(): ?\action_link {
+        $url = new \moodle_url('/admin/category.php', ['category' => 'tool_objectfs']);
+        return new \action_link($url, get_string('pluginname', 'tool_objectfs'));
+    }
+
+    /**
+     * Get the result of the connection check using sdk credentials.
+     *
+     * @return result
+     */
+    public function get_result(): result {
+        $config = manager::get_objectfs_config();
+        $config->s3_usesdkcreds = 1;
+        $client = manager::get_client($config);
+
+        if (empty($client) || !$client->is_configured($config)) {
+            return new result(result::NA, get_string('check:connection:na', 'tool_objectfs'));
+        }
+
+        $connection = $client->test_connection();
+        if ($connection->success) {
+            return new result(result::INFO, get_string('settings:aws:sdkcredsok', 'tool_objectfs'));
+        }
+
+        return new result(result::INFO, get_string('settings:aws:sdkcredserror', 'tool_objectfs'));
+    }
+}

--- a/classes/local/store/s3/client.php
+++ b/classes/local/store/s3/client.php
@@ -469,6 +469,8 @@ class client extends object_client_base {
         ));
 
         if (empty($config->s3_usesdkcreds)) {
+            $settings->add(new \admin_setting_check('tool_objectfs/s3_checksdkcreds', new \tool_objectfs\check\s3_sdkcreds()));
+
             $settings->add(new \admin_setting_configtext(
                 'tool_objectfs/s3_key',
                 new \lang_string('settings:aws:key', 'tool_objectfs'),

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -49,7 +49,6 @@ $string['checktagging_status'] = 'Object tagging';
 $string['checktagging_sync_status'] = 'Object tagging sync status';
 $string['checktoken_expiry'] = 'Token expiry';
 $string['client_not_available'] = 'The configured remote client is not available. Please ensure it is installed correctly.';
-$string['connectionstatus'] = 'Connection status';
 $string['delete_local_empty_directories_task'] = 'Object file system delete local empty directories task';
 $string['delete_local_objects_task'] = 'Object file system delete local objects task';
 $string['delete_orphaned_object_metadata_task'] = 'Object file system delete orphaned metadata task';

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -43,6 +43,7 @@ $string['check:tokenexpiry:na'] = 'Token expiry check not implemented for filesy
 $string['check_objects_location_task'] = 'Object file system check objects location task';
 $string['checkconnection'] = 'Object store connection status';
 $string['checkproxy_range_request'] = 'Pre-signed URL range request proxy';
+$string['checks3_sdkcreds'] = 'SDK credential provider chain';
 $string['checktagging_migration_status'] = 'Object tagging migration status';
 $string['checktagging_status'] = 'Object tagging';
 $string['checktagging_sync_status'] = 'Object tagging sync status';
@@ -143,8 +144,8 @@ $string['settings:aws:key_prefix'] = 'Prefix to use in bucket';
 $string['settings:aws:key_prefix_help'] = 'Prefix to use inside Amazon S3 bucket. Must end with trailing slash when set. Leave blank to use root of bucket.';
 $string['settings:aws:region'] = 'region';
 $string['settings:aws:region_help'] = 'Amazon S3 API gateway region.';
-$string['settings:aws:sdkcredserror'] = 'Couldn\'t find AWS credentials. It\'s unsafe to enable this setting. Follow up <a href="https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html">AWS documentation</a>.';
-$string['settings:aws:sdkcredsok'] = 'AWS credentials found. This setting can be safely enabled.';
+$string['settings:aws:sdkcredserror'] = 'AWS credentials not found in the credential provider chain. Using the chain without credentials is unsafe, use an S3 key and secret instead. Follow up <a href="https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html">AWS documentation</a>.';
+$string['settings:aws:sdkcredsok'] = 'AWS credentials found in the credential provider chain.';
 $string['settings:aws:secret'] = 'Secret';
 $string['settings:aws:secret_help'] = 'Amazon S3 secret credential.';
 $string['settings:aws:usesdkcreds'] = 'Use the default credential provider chain to find AWS credentials';

--- a/lang/en/tool_objectfs.php
+++ b/lang/en/tool_objectfs.php
@@ -289,7 +289,6 @@ $string['settings:taggingstatus'] = 'Tagging status';
 $string['settings:taggingstatuscounts'] = 'Tag sync status overview';
 $string['settings:tagsources'] = 'Tag sources';
 $string['settings:testingdescr'] = 'This setting is mainly for testing purposes and introduces overhead to check the location.';
-$string['settings:testingheader'] = 'Test Settings';
 $string['settings:tokenexpirywarnperiod'] = 'Token expiry warn period';
 $string['settings:useproxy'] = 'Use proxy';
 $string['settings:useproxy_help'] = 'Objectfs can use configured proxy to reach external storage.';

--- a/settings.php
+++ b/settings.php
@@ -148,6 +148,13 @@ if ($ADMIN->fulltree) {
         DAYSECS
     ));
 
+    $settings->add(new admin_setting_configcheckbox(
+        'tool_objectfs/preferexternal',
+        new lang_string('settings:preferexternal', 'tool_objectfs'),
+        '',
+        ''
+    ));
+
     $settings->add(new admin_setting_heading(
         'tool_objectfs/filetransfersettings',
         new lang_string('settings:filetransferheader', 'tool_objectfs'),
@@ -351,19 +358,6 @@ if ($ADMIN->fulltree) {
             $summary
         ));
     }
-
-    $settings->add(new admin_setting_heading(
-        'tool_objectfs/testsettings',
-        new lang_string('settings:testingheader', 'tool_objectfs'),
-        ''
-    ));
-
-    $settings->add(new admin_setting_configcheckbox(
-        'tool_objectfs/preferexternal',
-        new lang_string('settings:preferexternal', 'tool_objectfs'),
-        '',
-        ''
-    ));
 
     // Tagging settings.
     $settings->add(new admin_setting_heading(

--- a/settings.php
+++ b/settings.php
@@ -207,6 +207,8 @@ if ($ADMIN->fulltree) {
         \tool_objectfs\local\manager::get_available_fs_list()
     ));
 
+    $settings->add(new admin_setting_check('tool_objectfs/connectionstatus', new connection(), true));
+
     $client = \tool_objectfs\local\manager::get_client($config);
     if ($client && $client->get_availability()) {
         $settings = $client->define_client_section($settings, $config);
@@ -421,15 +423,6 @@ if ($ADMIN->fulltree) {
         get_string('settings:overrideobjecttags:desc', 'tool_objectfs'),
         1
     ));
-
-    // Connection status.
-    $settings->add(new admin_setting_heading(
-        'tool_objectfs/connectionstatus',
-        new lang_string('connectionstatus', 'tool_objectfs'),
-        ''
-    ));
-
-    $settings->add(new admin_setting_check('tool_objectfs/check_connectionstatus', new connection(), true));
 
     // Tagging status.
     $settings->add(new admin_setting_heading(

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026041009;      // The current plugin version (Date: YYYYMMDDXX).
-$plugin->release   = 2026041009;      // Same as version.
+$plugin->version   = 2026041010;      // The current plugin version (Date: YYYYMMDDXX).
+$plugin->release   = 2026041010;      // Same as version.
 $plugin->requires  = 2024042200;      // Requires 4.4.
 $plugin->component = "tool_objectfs";
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
- Re-add s3 credential provider chain check that was removed by mistake in #729 -  checks whether the it is safe to enable the use credential provider chain setting. This has been converted to use the check API and only provides information relevant to the use of a single setting so is only required on settings page when not checked. The results of this check have been also updated to INFO and lang strings made more descriptive.
- Move connection status to the above where the client settings are set, so status is visible when updating client settings.
- Cherry-pick #641 